### PR TITLE
Allow ctrl-c interrupts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HallThruster"
 uuid = "2311f341-5e6d-4941-9e3e-3ce0ae0d9ed6"
 authors = ["Thomas Marks <marksta@umich.edu>"]
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/HallThruster.jl
+++ b/src/HallThruster.jl
@@ -80,7 +80,7 @@ function example_simulation(;ncells, duration, dt, nsave)
         wall_loss_model = WallSheath(BoronNitride, 0.15)
     )
     sol_1 = HallThruster.run_simulation(config_1; ncells, duration, dt, nsave, verbose = false)
-    
+
     config_2 = HallThruster.Config(;
         thruster = HallThruster.SPT_100,
         domain = (0.0u"cm", 8.0u"cm"),

--- a/src/simulation/update_electrons.jl
+++ b/src/simulation/update_electrons.jl
@@ -8,6 +8,9 @@ function update_electrons!(U, params, t = 0)
         errors, channel_area
     ) = params.cache
 
+    # Allow for system interrupts
+    yield()
+
     # Update the current iteration
     params.iteration[1] += 1
 


### PR DESCRIPTION
Fixes #108 by inserting a `yield()` once per iteration. No noticeable performance impact.

@DecBrick