### PR TITLE
Override B-field for SPT-100

### DIFF
--- a/src/simulation/simulation.jl
+++ b/src/simulation/simulation.jl
@@ -347,8 +347,12 @@ function run_simulation(json_content::JSON3.Object; single_section = false, nons
 
     geometry = Geometry1D(;channel_length, outer_radius, inner_radius)
 
-    bfield_data = readdlm(magnetic_field_file, ',')
-    bfield_func = HallThruster.LinearInterpolation(bfield_data[:, 1], bfield_data[:, 2])
+    if thruster_name == "SPT-100"
+        bfield_func = HallThruster.B_field_SPT_100 $ (0.016, channel_length)
+    else
+        bfield_data = readdlm(magnetic_field_file, ',')
+        bfield_func = HallThruster.LinearInterpolation(bfield_data[:, 1], bfield_data[:, 2])
+    end
 
     thruster = HallThruster.Thruster(;
         name = thruster_name,


### PR DESCRIPTION
Quick way to load in the SPT-100 B-field definition from the [FFM Hara](https://doi.org/10.1063/5.0021474) model based on the `thruster_name` JSON input. 

Looks like `magnetic_field_file` is a required input, and so it will get overridden with this change if SPT-100 is specified.

A better implementation might make `magnetic_field_file` optional and then have a set of good defaults for the bfield_func. I leave that up to you.