### PR TITLE
Some optimizations

### DIFF
--- a/src/collisions/collision_frequencies.jl
+++ b/src/collisions/collision_frequencies.jl
@@ -2,7 +2,7 @@
     freq_electron_neutral(model::ElectronNeutralModel, nn, Tev)
 Effective frequency of electron scattering caused by collisions with neutrals
 """
-function freq_electron_neutral(collisions::Vector{ElasticCollision{T}}, nn::Number, Tev::Number) where T
+@inline function freq_electron_neutral(collisions::Vector{ElasticCollision{T}}, nn::Number, Tev::Number) where T
     νen = 0.0
     @inbounds for c in collisions
         νen += c.rate_coeff(3/2 * Tev) * nn
@@ -22,40 +22,11 @@ Effective frequency at which electrons are scattered due to collisions with ions
 """
 @inline freq_electron_ion(ne::Number, Tev::Number, Z::Number) = 2.9e-12 * Z^2 * ne * coulomb_logarithm(ne, Tev, Z) / sqrt(Tev^3)
 
-function compute_Z_eff(U, params, i::Int)
-    (;index) = params
-    mi = params.config.propellant.m
-    # Compute effective charge state
-    ne = electron_density(U, params, i)
-    ni_sum = sum(U[index.ρi[Z], i]/mi for Z in 1:params.config.ncharge)
-    Z_eff = ne / ni_sum
-    return Z_eff
-end
-
-function freq_electron_ion(U, params, i::Int)
-    if params.config.electron_ion_collisions
-        # Compute effective charge state
-        ne = params.cache.ne[i]
-        Z_eff = params.cache.Z_eff[i]
-        Tev = params.cache.Tev[i]
-        νei = Tev ≤ 0.0 || ne ≤ 0.0 || Z_eff < 1 ? 0.0 : freq_electron_ion(ne, Tev, Z_eff)
-        return νei
-    else
-        return 0.0
-    end
-end
-
 """
     freq_electron_electron(ne, Tev)
 Effective frequency at which electrons are scattered due to collisions with other electrons
 """
 @inline freq_electron_electron(ne::Number, Tev::Number) = 5e-12 * ne * coulomb_logarithm(ne, Tev) / sqrt(Tev^3)
-
-function freq_electron_electron(U, params, i)
-    ne = params.cache.ne[i]
-    Tev = params.cache.Tev[i]
-    return freq_electron_electron(ne, Tev)
-end
 
 """
     coulomb_logarithm(ne, Tev, Z = 1)

--- a/src/collisions/collision_frequencies.jl
+++ b/src/collisions/collision_frequencies.jl
@@ -20,7 +20,7 @@ end
     freq_electron_ion(ne, Tev, Z)
 Effective frequency at which electrons are scattered due to collisions with ions
 """
-@inline freq_electron_ion(ne::Number, Tev::Number, Z::Number) = 2.9e-12 * Z^2 * ne * coulomb_logarithm(ne, Tev, Z) / Tev^1.5
+@inline freq_electron_ion(ne::Number, Tev::Number, Z::Number) = 2.9e-12 * Z^2 * ne * coulomb_logarithm(ne, Tev, Z) / sqrt(Tev^3)
 
 function compute_Z_eff(U, params, i::Int)
     (;index) = params
@@ -49,7 +49,7 @@ end
     freq_electron_electron(ne, Tev)
 Effective frequency at which electrons are scattered due to collisions with other electrons
 """
-@inline freq_electron_electron(ne::Number, Tev::Number) = 5e-12 * ne * coulomb_logarithm(ne, Tev) / Tev^1.5
+@inline freq_electron_electron(ne::Number, Tev::Number) = 5e-12 * ne * coulomb_logarithm(ne, Tev) / sqrt(Tev^3)
 
 function freq_electron_electron(U, params, i)
     ne = params.cache.ne[i]

--- a/src/physics/thermal_conductivity.jl
+++ b/src/physics/thermal_conductivity.jl
@@ -50,7 +50,7 @@ function (model::Mitchner)(κ, params)
         #calculate mobility using above collision frequency
         mobility = electron_mobility(ν, params.cache.B[i])
         #final calculation
-        κ[i] = (2.4 / (1 + params.cache.νei[i]   / √(2) / ν))   * mobility * params.cache.ne[i] * params.cache.Tev[i]
+        κ[i] = (2.4 / (1 + params.cache.νei[i] / (√(2) * ν))) * mobility * params.cache.ne[i] * params.cache.Tev[i]
     end
     return κ
 end

--- a/src/simulation/electronenergy.jl
+++ b/src/simulation/electronenergy.jl
@@ -24,12 +24,6 @@ function update_electron_energy!(U, params, dt)
 
     bϵ[end] = 1.5 * Te_R * ne[end]
 
-    # Needed to compute excitation and ionization frequencies in first and last cells,
-    # Need a better solution, because the signature of this function doesn't make it clear
-    # That params.cache.νex and params.cache.νei are being modified
-    _ = inelastic_losses!(U, params, 1)
-    _ = inelastic_losses!(U, params, ncells)
-
     @inbounds for i in 2:ncells-1
         Q = source_electron_energy(U, params, i)
         # User-provided source term

--- a/src/simulation/sourceterms.jl
+++ b/src/simulation/sourceterms.jl
@@ -45,7 +45,6 @@ function apply_reactions!(dU::AbstractArray{T}, U::AbstractArray{T}, params, i::
         end
     end
 
-   # @show νiz[i]
     params.cache.dt_iz[i] = dt_max
 end
 
@@ -104,7 +103,7 @@ end
 
 function excitation_losses!(U, params, i)
     (;excitation_reactions, cache, excitation_reactant_indices) = params
-    (;νex, νiz, Tev, inelastic_losses, K) = cache
+    (;νex, Tev, inelastic_losses) = cache
     mi = params.config.propellant.m
     ne = cache.ne[i]
 
@@ -113,7 +112,7 @@ function excitation_losses!(U, params, i)
         0.0
     else
         # Include kinetic energy contribution
-        K[i]
+        cache.K[i]
     end
 
     # Total electron energy

--- a/src/simulation/update_electrons.jl
+++ b/src/simulation/update_electrons.jl
@@ -85,7 +85,7 @@ function update_electrons!(U, params, t = 0)
     end
 
     # Update anomalous transport
-    params.config.anom_model(νan, params)
+    t > 0 && params.config.anom_model(νan, params)
 
     # Smooth anomalous transport model
     if params.config.anom_smoothing_iters > 0

--- a/src/simulation/update_electrons.jl
+++ b/src/simulation/update_electrons.jl
@@ -20,126 +20,104 @@ function update_electrons!(U, params, t = 0)
 
     ncells = size(U, 2)
 
-    t_sub = 0.0
-    num_subcycles = 0
+    # Update electron quantities
+    @inbounds for i in 1:ncells
 
-    while t_sub < params.dt[]
-        num_subcycles += 1
-
-        # Update electron quantities
-        @inbounds for i in 1:ncells
-
-            # Compute neutral number densities for each neutral fluid
-            nn_tot[i] = 0.0
-            for j in 1:params.num_neutral_fluids
-                nn[j, i] = U[index.ρn[j], i] / params.config.propellant.m
-                nn_tot[i] += nn[j, i]
-            end
-
-            # Compute ion densities and velocities
-            for Z in 1:params.config.ncharge
-                ni[Z, i] = U[index.ρi[Z], i] / params.config.propellant.m
-                ui[Z, i] = U[index.ρiui[Z], i] / U[index.ρi[Z], i]
-                niui[Z, i] = U[index.ρiui[Z], i] / params.config.propellant.m
-            end
-
-            # Compute electron number density, making sure it is above floor
-            ne[i] = max(params.config.min_number_density, electron_density(U, params, i))
-
-            # Same with electron temperature
-            Tev[i] = 2/3 * max(params.config.min_electron_temperature, nϵ[i]/ne[i])
-
-            pe[i] = if params.config.LANDMARK
-                # The LANDMARK benchmark uses nϵ instead of pe in the potential solver, but we use pe, so
-                # we need to define pe = 3/2 ne Tev
-                3/2 * ne[i] * Tev[i]
-            else
-                # Otherwise, just use typical ideal gas law.
-                ne[i] * Tev[i]
-            end
-            # Compute electron-neutral and electron-ion collision frequencies
-            νen[i] = freq_electron_neutral(U, params, i)
-            νei[i] = freq_electron_ion(U, params, i)
-
-            # Compute total classical collision frequency
-            νc[i] = νen[i] + νei[i]
-            if !params.config.LANDMARK
-                # Add momentum transfer due to ionization and excitation
-                νc[i] += νiz[i] + νex[i]
-            end
-
-            # Compute anomalous collision frequency and wall collision frequencies
-            νew[i] = freq_electron_wall(params.config.wall_loss_model, U, params, i)
+        # Compute neutral number densities for each neutral fluid
+        nn_tot[i] = 0.0
+        for j in 1:params.num_neutral_fluids
+            nn[j, i] = U[index.ρn[j], i] / params.config.propellant.m
+            nn_tot[i] += nn[j, i]
         end
 
-        # Update anomalous transport
-        params.config.anom_model(νan, params)
-
-        # Smooth anomalous transport model
-        if params.config.anom_smoothing_iters > 0
-            smooth!(νan, params.cache.cell_cache_1, iters = params.config.anom_smoothing_iters)
+        # Compute ion densities and velocities
+        for Z in 1:params.config.ncharge
+            ni[Z, i] = U[index.ρi[Z], i] / params.config.propellant.m
+            ui[Z, i] = U[index.ρiui[Z], i] / U[index.ρi[Z], i]
+            niui[Z, i] = U[index.ρiui[Z], i] / params.config.propellant.m
         end
 
-        @inbounds for i in 1:ncells
-            # Multiply by anom anom multiplier for PID control
-            νan[i] *= anom_multiplier[]
+        # Compute electron number density, making sure it is above floor
+        ne[i] = max(params.config.min_number_density, electron_density(U, params, i))
 
-            # Compute total collision frequency and electron mobility
-            νe[i] = νc[i] + νan[i] + νew[i]
-            μ[i] = electron_mobility(νe[i], B[i])
+        # Same with electron temperature
+        Tev[i] = 2/3 * max(params.config.min_electron_temperature, nϵ[i]/ne[i])
 
-            # Effective ion charge state (density-weighted average charge state)
-            Z_eff[i] = compute_Z_eff(U, params, i)
-
-            # Ion current
-            ji[i] = ion_current_density(U, params, i)
-        end
-
-        # Compute anode sheath potential
-        Vs[] = anode_sheath_potential(U, params)
-
-        # Compute the discharge current by integrating the momentum equation over the whole domain
-        Id[] = discharge_current(U, params)
-
-        # Compute the electron velocity and electron kinetic energy
-        @inbounds for i in 1:ncells
-            # je + ji = Id / A
-            ue[i] = (ji[i] - Id[] / channel_area[i]) / e / ne[i]
-
-            # Kinetic energy in both axial and azimuthal directions is accounted for
-            params.cache.K[i] = electron_kinetic_energy(U, params, i)
-        end
-
-        # Compute potential gradient and pressure gradient
-        compute_pressure_gradient!(∇pe, params)
-
-        # Compute electric field
-        compute_electric_field!(∇ϕ, params)
-
-        # update electrostatic potential and potential gradient on edges
-        solve_potential!(ϕ, params)
-
-        if params.adaptive
-            dt_min = Inf
-
-            @inbounds for i in 2:ncells-1
-                Q = source_electron_energy(U, params, i)
-                dt_min = min(dt_min, abs(params.CFL * 3 * ne[i] * Tev[i] / Q))
-            end
-
-            dt_sub = min(dt_min, params.dt[] - t_sub)
+        pe[i] = if params.config.LANDMARK
+            # The LANDMARK benchmark uses nϵ instead of pe in the potential solver, but we use pe, so
+            # we need to define pe = 3/2 ne Tev
+            3/2 * ne[i] * Tev[i]
         else
-            dt_sub = params.dt[]
+            # Otherwise, just use typical ideal gas law.
+            ne[i] * Tev[i]
+        end
+        # Compute electron-neutral and electron-ion collision frequencies
+        νen[i] = freq_electron_neutral(U, params, i)
+        νei[i] = freq_electron_ion(U, params, i)
+
+        # Compute total classical collision frequency
+        νc[i] = νen[i] + νei[i]
+        if !params.config.LANDMARK
+            # Add momentum transfer due to ionization and excitation
+            νc[i] += νiz[i] + νex[i]
         end
 
-        #update thermal conductivity
-        params.config.conductivity_model(κ, params)
-
-        # Update the electron temperature and pressure
-        update_electron_energy!(U, params, dt_sub)
-
-        t_sub += dt_sub
+        # Compute anomalous collision frequency and wall collision frequencies
+        νew[i] = freq_electron_wall(params.config.wall_loss_model, U, params, i)
     end
+
+    # Update anomalous transport
+    params.config.anom_model(νan, params)
+
+    # Smooth anomalous transport model
+    if params.config.anom_smoothing_iters > 0
+        smooth!(νan, params.cache.cell_cache_1, iters = params.config.anom_smoothing_iters)
+    end
+
+    @inbounds for i in 1:ncells
+        # Multiply by anom anom multiplier for PID control
+        νan[i] *= anom_multiplier[]
+
+        # Compute total collision frequency and electron mobility
+        νe[i] = νc[i] + νan[i] + νew[i]
+        μ[i] = electron_mobility(νe[i], B[i])
+
+        # Effective ion charge state (density-weighted average charge state)
+        Z_eff[i] = compute_Z_eff(U, params, i)
+
+        # Ion current
+        ji[i] = ion_current_density(U, params, i)
+    end
+
+    # Compute anode sheath potential
+    Vs[] = anode_sheath_potential(U, params)
+
+    # Compute the discharge current by integrating the momentum equation over the whole domain
+    Id[] = discharge_current(U, params)
+
+    # Compute the electron velocity and electron kinetic energy
+    @inbounds for i in 1:ncells
+        # je + ji = Id / A
+        ue[i] = (ji[i] - Id[] / channel_area[i]) / e / ne[i]
+
+        # Kinetic energy in both axial and azimuthal directions is accounted for
+        params.cache.K[i] = electron_kinetic_energy(U, params, i)
+    end
+
+    # Compute potential gradient and pressure gradient
+    compute_pressure_gradient!(∇pe, params)
+
+    # Compute electric field
+    compute_electric_field!(∇ϕ, params)
+
+    # update electrostatic potential and potential gradient on edges
+    solve_potential!(ϕ, params)
+
+    #update thermal conductivity
+    params.config.conductivity_model(κ, params)
+
+    # Update the electron temperature and pressure
+    update_electron_energy!(U, params, params.dt[])
 
     # Update the anomalous collision frequency multiplier to match target
     # discharge current

--- a/src/wall_loss_models/wall_sheath.jl
+++ b/src/wall_loss_models/wall_sheath.jl
@@ -39,7 +39,7 @@ compute wall sheath to be used for radiative losses and loss to wall.
 Goebel Katz equ. 7.3-29, 7.3-44. Assumed nₑuₑ/nᵢuᵢ ≈ 0.5
 Sheath potentials are positive by convention in HallThruster.jl.
 """
-@inline @fastmath sheath_potential(Tev, γ, mi) = Tev*log((1 - γ) * sqrt(mi/π/me/2))
+@inline @fastmath sheath_potential(Tev, γ, mi) = Tev * log((1 - γ) * sqrt(mi/π/me/2))
 
 Base.@kwdef struct WallSheath <: WallLossModel
     material::WallMaterial

--- a/test/order_verification/ovs_energy.jl
+++ b/test/order_verification/ovs_energy.jl
@@ -35,7 +35,7 @@ ue_func = eval(build_function(expand_derivatives(ue), [x]))
 ρn_func = eval(build_function(ρn, [x]))
 ϵ_func = eval(build_function(ϵ, [x]))
 
-k(ϵ) = 12.12 * OVS_rate_coeff_iz(ϵ) + 8.32 * OVS_rate_coeff_ex(ϵ)
+k(ϵ) = 8.32 * OVS_rate_coeff_ex(ϵ)
 W(ϵ) = 1e7 * ϵ * exp(-20 / ϵ)
 energy_eq = Dt(nϵ) + Dx(5/3 * nϵ * ue - 10/9 * μ * nϵ * Dx(nϵ/ne)) + ne * (-ue * Dx(ϕ) + nn * k(ϵ) + W(ϵ))
 source_energy = eval(build_function(expand_derivatives(energy_eq), [x]))
@@ -48,6 +48,9 @@ function solve_energy!(U, params, max_steps, dt, rtol = sqrt(eps(Float64)))
     res0 = 0.0
     while iter < max_steps && abs(residual / res0) > rtol
         HallThruster.update_electron_energy!(U, params, dt)
+        params.νiz[i] .= 0.0
+        params.νex[i] .= 0.0
+        params.inelastic_losses[i] .= 0.0
         params.config.conductivity_model(params.cache.κ, params) # update thermal conductivity
         residual = Lp_norm(params.cache.nϵ .- nϵ_old, 2)
         if iter == 1

--- a/test/order_verification/ovs_energy.jl
+++ b/test/order_verification/ovs_energy.jl
@@ -48,9 +48,9 @@ function solve_energy!(U, params, max_steps, dt, rtol = sqrt(eps(Float64)))
     res0 = 0.0
     while iter < max_steps && abs(residual / res0) > rtol
         HallThruster.update_electron_energy!(U, params, dt)
-        params.νiz[i] .= 0.0
-        params.νex[i] .= 0.0
-        params.inelastic_losses[i] .= 0.0
+        params.cache.νiz .= 0.0
+        params.cache.νex .= 0.0
+        params.cache.inelastic_losses .= 0.0
         params.config.conductivity_model(params.cache.κ, params) # update thermal conductivity
         residual = Lp_norm(params.cache.nϵ .- nϵ_old, 2)
         if iter == 1

--- a/test/order_verification/ovs_ions.jl
+++ b/test/order_verification/ovs_ions.jl
@@ -144,7 +144,9 @@ function solve_ions(ncells, scheme; t_end = 1e-4)
     dt_cell .= dt[]
     k = zeros(size(U))
     u1 = zeros(size(U))
-    cache = (;k, u1, ue, μ, F, UL, UR, ∇ϕ, λ_global, channel_area, dA_dz, dt_cell, dt, dt_u, dt_iz, dt_E, nϵ)
+    inelastic_losses = zeros(ncells+2)
+    νiz = zeros(ncells+2)
+    cache = (;k, u1, ue, μ, F, UL, UR, ∇ϕ, λ_global, channel_area, dA_dz, dt_cell, dt, dt_u, dt_iz, dt_E, nϵ, νiz, inelastic_losses)
 
     params = (;
         index,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,8 @@ using Symbolics
 include("order_verification/ovs_funcs.jl")
 include("order_verification/ovs_energy.jl")
 include("order_verification/ovs_ions.jl")
-
 @testset "Order verification (electron energy)" begin
+
     vfunc = x -> OVS_Energy.verify_energy(x)
     refinements = refines(6, 20, 2)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,8 @@ using Symbolics
 include("order_verification/ovs_funcs.jl")
 include("order_verification/ovs_energy.jl")
 include("order_verification/ovs_ions.jl")
-@testset "Order verification (electron energy)" begin
 
+@testset "Order verification (electron energy)" begin
     vfunc = x -> OVS_Energy.verify_energy(x)
     refinements = refines(6, 20, 2)
 

--- a/test/unit_tests/test_electrons.jl
+++ b/test/unit_tests/test_electrons.jl
@@ -23,7 +23,7 @@
 
     index = (ρn = [1], ρi = [2], nϵ = 3)
     cache = (;nn_tot = [nn], ne = [ne], B = [B], Tev = [Tev], Z_eff = [1.0], νan = [0.0], κ = [0.0],
-             μ = μ_e, νc = ν_c, 
+             μ = μ_e, νc = ν_c,
     )
     c1 = 1/160
     c2 = 1/16
@@ -56,18 +56,13 @@
     @test HallThruster.freq_electron_neutral(U, params_none, 1) == 0.0
 
     Z = 1
-
-    @test HallThruster.freq_electron_ion(U, params_landmark, 1) == 0.0
-    @test HallThruster.freq_electron_ion(U, params_gk, 1) == 2.9e-12 * Z^2 * ne * HallThruster.coulomb_logarithm(ne, Tev, Z) / Tev^1.5
-    @test HallThruster.freq_electron_ion(U, params_none, 1) == 0.0
-
+    @test HallThruster.freq_electron_ion(ne, Tev, Z) == 2.9e-12 * Z^2 * ne * HallThruster.coulomb_logarithm(ne, Tev, Z) / Tev^1.5
     @test HallThruster.freq_electron_electron(ne, Tev) == 5e-12 * ne * HallThruster.coulomb_logarithm(ne, Tev) / Tev^1.5
-    @test HallThruster.freq_electron_electron(U, params_landmark, 1) == 5e-12 * ne * HallThruster.coulomb_logarithm(ne, Tev) / Tev^1.5
 
 
     params_landmark.config.anom_model(params_landmark.cache.νan, params_landmark)
     params_none.config.anom_model(params_none.cache.νan, params_none)
-  
+
     model = HallThruster.NoAnom()
 
     model(params_landmark.cache.νan, params_landmark)
@@ -76,7 +71,7 @@
 
     @test HallThruster.ELECTRON_CONDUCTIVITY_LOOKUP(1) == 4.66
     @test HallThruster.ELECTRON_CONDUCTIVITY_LOOKUP(1.5) == 4.33
-    
+
     conductivity_model = HallThruster.LANDMARK_conductivity()
     conductivity_model(params_landmark.cache.κ, params_landmark)
     @test params_landmark.cache.κ[1] ≈ 5/3 * μ_e * ne * Tev

--- a/test/unit_tests/test_walls.jl
+++ b/test/unit_tests/test_walls.jl
@@ -224,10 +224,8 @@ end
     params_no_losses = (;base_params..., config = config_no_losses)
 
     for i in 1:4
-        cache.Z_eff[i] = HallThruster.compute_Z_eff(U, params_no_losses, i)
+        cache.Z_eff[i] = (ni_1 + 2 * ni_2) / (ni_1 + ni_2)
     end
-
-    @test cache.Z_eff[1] ≈ (ni_1 + 2 * ni_2) / (ni_1 + ni_2)
 
     u_bohm_1 = u_bohm
     u_bohm_2 = sqrt(2) * u_bohm


### PR DESCRIPTION
# What's changed
- made version of `interpolate` specialized for `StepRangeLen`
- Swapped out `Tev^1.5` in electron-ion collision frequency computation for `sqrt(Tev^3)`
- Compute nu_iz and ionization component of inelastic losses during heavy species update
- remove compute_z_eff and rearrange some computations in update_electrons

Using an example SPT-100 simulation with 150 cells and only singly-charged ions as a benchmark, I recorded a time of around 1.56 seconds before these optimizations and 1.00 seconds after these optimizations. That's about a 36% speedup, due primarily to the first change and third changes. For simulations with more charge states, these gains will be larger as the primary effect of the `interpolate` and ionization rate changes is to speed up reaction rate calculation.

Profiling shows that reaction rate computation is still a major bottleneck for the code. Next PR will focus on improving this by separating out reaction computation into its own step in the main solver loop.