### PR TITLE
Reactions refactor

### DIFF
--- a/src/collisions/collision_frequencies.jl
+++ b/src/collisions/collision_frequencies.jl
@@ -2,10 +2,10 @@
     freq_electron_neutral(model::ElectronNeutralModel, nn, Tev)
 Effective frequency of electron scattering caused by collisions with neutrals
 """
-@inline function freq_electron_neutral(collisions::Vector{ElasticCollision{T}}, nn::Number, Tev::Number) where T
+@inline function freq_electron_neutral(collisions::Vector{ElasticCollision}, nn::Number, Tev::Number)
     νen = 0.0
     @inbounds for c in collisions
-        νen += c.rate_coeff(3/2 * Tev) * nn
+        νen += rate_coeff(c, 3/2 * Tev) * nn
     end
     return νen
 end

--- a/src/collisions/collision_frequencies.jl
+++ b/src/collisions/collision_frequencies.jl
@@ -2,18 +2,18 @@
     freq_electron_neutral(model::ElectronNeutralModel, nn, Tev)
 Effective frequency of electron scattering caused by collisions with neutrals
 """
-@inline function freq_electron_neutral(collisions::Vector{ElasticCollision}, nn::Number, Tev::Number)
+@inline function freq_electron_neutral(model::ElectronNeutralModel, collisions::Vector{ElasticCollision}, nn::Number, Tev::Number)
     νen = 0.0
     @inbounds for c in collisions
-        νen += rate_coeff(c, 3/2 * Tev) * nn
+        νen += rate_coeff(model, c, 3/2 * Tev) * nn
     end
     return νen
 end
 
-function freq_electron_neutral(params::NamedTuple, i::Int)
+function freq_electron_neutral(params, i)
     nn = params.cache.nn[i]
     Tev = params.cache.Tev[i]
-    return freq_electron_neutral(params.electron_neutral_collisions, nn, Tev)
+    return freq_electron_neutral(params.config.electron_neutral_model, params.electron_neutral_collisions, nn, Tev)
 end
 
 """

--- a/src/collisions/elastic.jl
+++ b/src/collisions/elastic.jl
@@ -5,42 +5,35 @@ end
 
 abstract type ElectronNeutralModel <: ReactionModel end
 
+# Definitions for NoElectronNeutral
 struct NoElectronNeutral <: ElectronNeutralModel end
-
 supported_species(::NoElectronNeutral) = Gas[]
-
 load_reactions(::NoElectronNeutral, species) = ElasticCollision[]
+rate_coeff(::NoElectronNeutral, ::Reaction, ::Float64) = 0.0
 
+# Definitions for LandmarkElectronNeutral
 struct LandmarkElectronNeutral <: ElectronNeutralModel end
-
 supported_species(::LandmarkElectronNeutral) = [Xenon]
+load_reactions(::LandmarkElectronNeutral, species) = [ElasticCollision(Xenon(0), Float64[])]
+rate_coeff(::LandmarkElectronNeutral, ::Reaction, ::Float64) = 2.5e-13
 
-function load_reactions(::LandmarkElectronNeutral, species)
-    landmark_electron_neutral = fill(2.5e-13, 256)
-    return [ElasticCollision(Xenon(0), landmark_electron_neutral)]
-end
-
-struct GKElectronNeutral <: ElectronNeutralModel end
-
-supported_species(::GKElectronNeutral) = [Xenon]
-
+# Definitions for GKElectronNeutral
 """
-    σ_en(Tev)
-
-Electron neutral collision cross section in m² as a function of electron temperature in eV.
+Electron neutral collision model as defined by
 Eq. 3.6-13, from Fundamentals of Electric Propulsion, Goebel and Katz, 2008.
-
 """
-@inline function σ_en(Tev)
-    return max(0.0, 6.6e-19 * ((Tev / 4 - 0.1) / (1 + (Tev / 4)^1.6)))
+struct GKElectronNeutral <: ElectronNeutralModel end
+supported_species(::GKElectronNeutral) = [Xenon]
+load_reactions(::GKElectronNeutral, species) = [ElasticCollision(Xenon(0), Float64[])]
+
+@inline σ_en(Tev) = max(0.0, 6.6e-19 * ((Tev / 4 - 0.1) / (1 + (Tev / 4)^1.6)))
+
+@inline function rate_coeff(::GKElectronNeutral, ::Reaction, energy::Float64)
+    Tev = 2/3 * energy
+    return σ_en(Tev) * electron_sound_speed(Tev)
 end
 
-function load_reactions(::GKElectronNeutral, species)
-    rate_coeff(ϵ) = σ_en(2/3 * ϵ) * electron_sound_speed(2/3 * ϵ)
-    return [ElasticCollision(Xenon(0), rate_coeff.(0:255))]
-end
-
-
+# Definitions for ElectronNeutralLookup
 Base.@kwdef struct ElectronNeutralLookup <: ElectronNeutralModel
     directories::Vector{String} = String[]
 end
@@ -57,15 +50,14 @@ function load_reactions(model::ElectronNeutralLookup, species)
         reactant = species_sorted[i]
         if reactant.Z > 0
             break
-        else
-            for folder in folders
-                filename = rate_coeff_filename(reactant, product, collision_type, folder)
-                if ispath(filename)
-                    _, rate_coeff = load_rate_coeffs(reactant, product, collision_type,folder)
-                    reaction = HallThruster.ElasticCollision(reactant, rate_coeff)
-                    push!(reactions, reaction)
-                    break
-                end
+        end
+        for folder in folders
+            filename = rate_coeff_filename(reactant, product, collision_type, folder)
+            if ispath(filename)
+                _, rate_coeff = load_rate_coeffs(reactant, product, collision_type,folder)
+                reaction = HallThruster.ElasticCollision(reactant, rate_coeff)
+                push!(reactions, reaction)
+                break
             end
         end
     end

--- a/src/collisions/elastic.jl
+++ b/src/collisions/elastic.jl
@@ -9,17 +9,16 @@ struct NoElectronNeutral <: ElectronNeutralModel end
 
 supported_species(::NoElectronNeutral) = Gas[]
 
-load_reactions(::NoElectronNeutral, species) = ElasticCollision{Nothing}[]
+load_reactions(::NoElectronNeutral, species) = ElasticCollision[]
 
 struct LandmarkElectronNeutral <: ElectronNeutralModel end
 
 supported_species(::LandmarkElectronNeutral) = [Xenon]
 
 function load_reactions(::LandmarkElectronNeutral, species)
-    landmark_electron_neutral = Returns(2.5e-13)
+    landmark_electron_neutral = fill(2.5e-13, 256)
     return [ElasticCollision(Xenon(0), landmark_electron_neutral)]
 end
-
 
 struct GKElectronNeutral <: ElectronNeutralModel end
 
@@ -38,7 +37,7 @@ end
 
 function load_reactions(::GKElectronNeutral, species)
     rate_coeff(ϵ) = σ_en(2/3 * ϵ) * electron_sound_speed(2/3 * ϵ)
-    return [ElasticCollision(Xenon(0), rate_coeff)]
+    return [ElasticCollision(Xenon(0), rate_coeff.(0:255))]
 end
 
 

--- a/src/collisions/elastic.jl
+++ b/src/collisions/elastic.jl
@@ -1,6 +1,6 @@
-Base.@kwdef struct ElasticCollision{I} <: Reaction
+Base.@kwdef struct ElasticCollision <: Reaction
     species::Species
-    rate_coeff::I
+    rate_coeffs::Vector{Float64}
 end
 
 abstract type ElectronNeutralModel <: ReactionModel end
@@ -10,7 +10,6 @@ struct NoElectronNeutral <: ElectronNeutralModel end
 supported_species(::NoElectronNeutral) = Gas[]
 
 load_reactions(::NoElectronNeutral, species) = ElasticCollision{Nothing}[]
-
 
 struct LandmarkElectronNeutral <: ElectronNeutralModel end
 

--- a/src/collisions/excitation.jl
+++ b/src/collisions/excitation.jl
@@ -1,7 +1,7 @@
-Base.@kwdef struct ExcitationReaction{I} <: Reaction
+Base.@kwdef struct ExcitationReaction <: Reaction
     energy::Float64
     reactant::Species
-    rate_coeff::I
+    rate_coeffs::Vector{Float64}
 end
 
 function Base.show(io::IO, i::ExcitationReaction)

--- a/src/collisions/excitation.jl
+++ b/src/collisions/excitation.jl
@@ -64,7 +64,7 @@ Supports only singly-charged Xenon.
 """
 struct LandmarkExcitationLookup <: ExcitationModel end
 
-function load_reactions(model::LandmarkExcitationLookup, species)
+function load_reactions(::LandmarkExcitationLookup, species)
     rates = readdlm(LANDMARK_RATES_FILE, ',', skipstart = 1)
     ϵ = rates[:, 1]
     k_iz = rates[:, 2]

--- a/src/collisions/excitation.jl
+++ b/src/collisions/excitation.jl
@@ -75,6 +75,8 @@ function load_reactions(model::LandmarkExcitationLookup, species)
     # We infer the excitation loss coefficient by subtracting the contribution of the ionization
     # loss coefficient from the inelastic loss term
     k_excitation = @. (k_loss - ionization_energy * k_iz) / excitation_energy
-    rate_coeff = LinearInterpolation(ϵ, k_excitation)
-    return [ExcitationReaction(excitation_energy, Xenon(0), rate_coeff)]
+    itp = LinearInterpolation(ϵ, k_excitation)
+    xs = 0:1.0:255
+    rate_coeffs = itp.(xs)
+    return [ExcitationReaction(excitation_energy, Xenon(0), rate_coeffs)]
 end

--- a/src/collisions/ionization.jl
+++ b/src/collisions/ionization.jl
@@ -1,8 +1,8 @@
-Base.@kwdef struct IonizationReaction{I} <: Reaction
+Base.@kwdef struct IonizationReaction <: Reaction
     energy::Float64
     reactant::Species
     product::Species
-    rate_coeff::I
+    rate_coeffs::Vector{Float64}
 end
 
 function Base.show(io::IO, i::IonizationReaction)

--- a/src/collisions/ionization.jl
+++ b/src/collisions/ionization.jl
@@ -74,6 +74,8 @@ function load_reactions(::LandmarkIonizationLookup, species)
     rates = readdlm(LANDMARK_RATES_FILE, ',', skipstart = 1)
     ϵ = rates[:, 1]
     k = rates[:, 2]
-    rate_coeff = LinearInterpolation(ϵ, k)
-    return [IonizationReaction(12.12, Xenon(0), Xenon(1), rate_coeff)]
+    itp = LinearInterpolation(ϵ, k)
+    xs = 0:1.0:255
+    rate_coeffs = itp.(xs)
+    return [IonizationReaction(12.12, Xenon(0), Xenon(1), rate_coeffs)]
 end

--- a/src/collisions/reactions.jl
+++ b/src/collisions/reactions.jl
@@ -1,5 +1,15 @@
 abstract type Reaction end
 
+function rate_coeff(rxn::Reaction, energy::Float64)
+    ind = Base.trunc(Int64, energy)
+    N = length(rxn.rate_coeffs) - 2
+    ind = ind > N ? N : ind
+    r1 = rxn.rate_coeffs[ind+1]
+    r2 = rxn.rate_coeffs[ind+2]
+    t = energy - ind
+    return (1 - t) * r1 + t * r2
+end
+
 function rate_coeff_filename(reactant, product, reaction_type, folder = REACTION_FOLDER)
     fname = if product === nothing
         joinpath(folder, join([reaction_type, repr(reactant)], "_") * ".dat")
@@ -56,8 +66,10 @@ function load_rate_coeffs(reactant, product, reaction_type, folder = REACTION_FO
     end
     ϵ = rates[:, 1]
     k = rates[:, 2]
-    rate_coeff = LinearInterpolation(ϵ, k, resample_uniform=true)
-    return energy, rate_coeff
+    itp = LinearInterpolation(ϵ, k, resample_uniform=true)
+    xs = 0:1.0:255
+    rate_coeffs = itp.(xs)
+    return energy, rate_coeffs
 end
 
 abstract type ReactionModel end

--- a/src/collisions/reactions.jl
+++ b/src/collisions/reactions.jl
@@ -121,13 +121,11 @@ function _load_reactions(model::ReactionModel, species)
 end
 
 function _indices(symbol, reactions, species_range_dict)
-    indices = [Int[] for _ in reactions]
+    indices = zeros(Int, length(reactions))
     for (i, reaction) in enumerate(reactions)
         species = getfield(reaction, symbol).symbol
-        ranges = species_range_dict[species]
-        for r in ranges
-            push!(indices[i], r[1])
-        end
+        range = species_range_dict[species]
+        indices[i] = range[1]
     end
     return indices
 end

--- a/src/collisions/reactions.jl
+++ b/src/collisions/reactions.jl
@@ -66,7 +66,7 @@ function load_rate_coeffs(reactant, product, reaction_type, folder = REACTION_FO
     end
     ϵ = rates[:, 1]
     k = rates[:, 2]
-    itp = LinearInterpolation(ϵ, k, resample_uniform=true)
+    itp = LinearInterpolation(ϵ, k)
     xs = 0:1.0:255
     rate_coeffs = itp.(xs)
     return energy, rate_coeffs

--- a/src/collisions/reactions.jl
+++ b/src/collisions/reactions.jl
@@ -68,7 +68,7 @@ abstract type ReactionModel end
 """
 By default, rate_coeff looks for a lookup table stored in the reaction struct
 """
-function rate_coeff(::ReactionModel, rxn::Reaction, energy::Float64)
+function rate_coeff(::ReactionModel, rxn::Reaction, energy)
     ind = Base.trunc(Int64, energy)
     N = length(rxn.rate_coeffs) - 2
     ind = ind > N ? N : ind

--- a/src/collisions/reactions.jl
+++ b/src/collisions/reactions.jl
@@ -1,14 +1,5 @@
 abstract type Reaction end
 
-function rate_coeff(rxn::Reaction, energy::Float64)
-    ind = Base.trunc(Int64, energy)
-    N = length(rxn.rate_coeffs) - 2
-    ind = ind > N ? N : ind
-    r1 = rxn.rate_coeffs[ind+1]
-    r2 = rxn.rate_coeffs[ind+2]
-    t = energy - ind
-    return (1 - t) * r1 + t * r2
-end
 
 function rate_coeff_filename(reactant, product, reaction_type, folder = REACTION_FOLDER)
     fname = if product === nothing
@@ -73,6 +64,19 @@ function load_rate_coeffs(reactant, product, reaction_type, folder = REACTION_FO
 end
 
 abstract type ReactionModel end
+
+"""
+By default, rate_coeff looks for a lookup table stored in the reaction struct
+"""
+function rate_coeff(::ReactionModel, rxn::Reaction, energy::Float64)
+    ind = Base.trunc(Int64, energy)
+    N = length(rxn.rate_coeffs) - 2
+    ind = ind > N ? N : ind
+    r1 = rxn.rate_coeffs[ind+1]
+    r2 = rxn.rate_coeffs[ind+2]
+    t = energy - ind
+    return (1 - t) * r1 + t * r2
+end
 
 """
     load_reactions(model::ReactionModel, species)::Vector{IonizationReaction}

--- a/src/simulation/configuration.jl
+++ b/src/simulation/configuration.jl
@@ -111,7 +111,7 @@ function Config(;
 
     anode_Te = convert_to_float64(anode_Te, u"eV")
     cathode_Te = convert_to_float64(cathode_Te, u"eV")
-    
+
     default_neutral_velocity = 150.0 # m/s
     default_neutral_temp = 500.0 # K
     if isnothing(neutral_velocity) && isnothing(neutral_temperature)
@@ -217,10 +217,10 @@ function configure_fluids(config)
     species = [f.species for f in fluids]
 
     fluid_ranges = ranges(fluids)
-    species_range_dict = Dict(Symbol(fluid.species) => UnitRange{Int64}[] for fluid in fluids)
+    species_range_dict = Dict(Symbol(fluid.species) => 0:0 for fluid in fluids)
 
     for (fluid, fluid_range) in zip(fluids, fluid_ranges)
-        push!(species_range_dict[Symbol(fluid.species)], fluid_range)
+        species_range_dict[Symbol(fluid.species)] = fluid_range
     end
 
     last_fluid_index = fluid_ranges[end][end]

--- a/src/simulation/electronenergy.jl
+++ b/src/simulation/electronenergy.jl
@@ -22,10 +22,13 @@ function update_electron_energy!(params, dt)
 
     bϵ[end] = 1.5 * Te_R * ne[end]
 
+    # Compute energy source terms
+    Q = cache.cell_cache_1
+    source_electron_energy!(Q, params)
+
     @inbounds for i in 2:ncells-1
-        Q = source_electron_energy(params, i)
         # User-provided source term
-        Q += config.source_energy(params, i)
+        Q[i] += config.source_energy(params, i)
 
         neL = ne[i-1]
         ne0 = ne[i]
@@ -117,7 +120,7 @@ function update_electron_energy!(params, dt)
         flux = 5/3 * nϵ0 * ue0
 
         # Explicit right-hand-side
-        bϵ[i] = nϵ[i] + dt * (Q - explicit * F_explicit)
+        bϵ[i] = nϵ[i] + dt * (Q[i] - explicit * F_explicit)
         bϵ[i] -= dt * flux * dlnA_dz
     end
 

--- a/src/simulation/restart.jl
+++ b/src/simulation/restart.jl
@@ -34,14 +34,14 @@ function read_restart(path::AbstractString)
     )
 end
 
-function load_restart(grid, fluids, config, path::AbstractString)
+function load_restart(grid, config, path::AbstractString)
     sol = read_restart(path)
-    U, cache = load_restart(grid, fluids, config, sol)
+    U, cache = load_restart(grid, config, sol)
     return U, cache
 end
 
-function load_restart(grid, fluids, config, sol::Solution)
-    U, cache = HallThruster.allocate_arrays(grid, fluids)
+function load_restart(grid, config, sol::Solution)
+    U, cache = HallThruster.allocate_arrays(grid, config)
 
     z_cell = sol.params.z_cell
 

--- a/src/simulation/simulation.jl
+++ b/src/simulation/simulation.jl
@@ -14,10 +14,16 @@ function allocate_arrays(grid, fluids, anom_model = HallThruster.NoAnom())
     ncells = grid.ncells + 2
     nedges = grid.ncells + 1
 
+    ncharge = maximum(f.species.Z for f in fluids)
+
+    # Main state vector
     U = zeros(nvariables, ncells)
-    B = zeros(ncells)
-    Aϵ = Tridiagonal(ones(ncells-1), ones(ncells), ones(ncells-1)) #for energy
-    bϵ = zeros(ncells) #for energy
+
+    # Caches for energy solve
+    Aϵ = Tridiagonal(ones(ncells-1), ones(ncells), ones(ncells-1))
+    bϵ = zeros(ncells)
+
+    # Collision frequencies
     νan = zeros(ncells)
     νc = zeros(ncells)
     νei = zeros(ncells)
@@ -25,35 +31,58 @@ function allocate_arrays(grid, fluids, anom_model = HallThruster.NoAnom())
     radial_loss_frequency = zeros(ncells)
     νew_momentum = zeros(ncells)
     νiw = zeros(ncells)
-    κ = zeros(ncells)
-    μ = zeros(ncells)
-    ϕ = zeros(ncells)
-    ∇ϕ = zeros(ncells)
-    ne = zeros(ncells)
-    nϵ = zeros(ncells)
-    Tev = zeros(ncells)
-    pe = zeros(ncells)
-    ∇pe = zeros(ncells)
-    ue = zeros(ncells)
-    F = zeros(nvariables, nedges)
-    UL = zeros(nvariables, nedges)
-    UR = zeros(nvariables, nedges)
-    Z_eff = zeros(ncells)
-    λ_global = zeros(length(fluids))
     νe = zeros(ncells)
     νiz = zeros(ncells)
     νex = zeros(ncells)
-    K   = zeros(ncells)
-    ji  = zeros(ncells)
 
+    # Magnetic field
+    B = zeros(ncells)
+
+    # Conductivity and mobility
+    κ = zeros(ncells)
+    μ = zeros(ncells)
+
+    # Potential and electric field
+    ϕ = zeros(ncells)
+    ∇ϕ = zeros(ncells)
+
+    # Electron number density
+    ne = zeros(ncells)
+
+    # Electron energy density
+    nϵ = zeros(ncells)
+
+    # Electron temperature and energy [eV]
+    Tev = zeros(ncells)
+    ϵ = zeros(ncells)
+
+    # Electron pressure and pressure gradient
+    pe = zeros(ncells)
+    ∇pe = zeros(ncells)
+
+    # Electron axial velocity and kinetic energy
+    ue = zeros(ncells)
+    K = zeros(ncells)
+
+    λ_global = zeros(length(fluids))
+
+    # Electron source terms
     ohmic_heating = zeros(ncells)
     wall_losses = zeros(ncells)
     inelastic_losses = zeros(ncells)
 
-    ncharge = maximum(f.species.Z for f in fluids)
+    # Effective charge number
+    Z_eff = zeros(ncells)
+
+    # Ion density, velocity, and number flux
     ni = zeros(ncharge, ncells)
     ui = zeros(ncharge, ncells)
     niui = zeros(ncharge, ncells)
+
+    # ion current
+    ji  = zeros(ncells)
+
+    # Neutral density
     nn = zeros(ncells)
     γ_SEE = zeros(ncells)
     Id  = [0.0]
@@ -64,6 +93,11 @@ function allocate_arrays(grid, fluids, anom_model = HallThruster.NoAnom())
     smoothing_time_constant = [0.0]
     errors = [0.0, 0.0, 0.0]
     dcoeffs = [0.0, 0.0, 0.0, 0.0]
+
+    # Edge state caches
+    F = zeros(nvariables, nedges)
+    UL = zeros(nvariables, nedges)
+    UR = zeros(nvariables, nedges)
 
     # timestepping caches
     k = copy(U)
@@ -84,21 +118,20 @@ function allocate_arrays(grid, fluids, anom_model = HallThruster.NoAnom())
     anom_variables = allocate_anom_variables(anom_model, size(U, 2))
 
     # Timesteps
-    dt_iz = zeros(ncells)
-    dt_E = zeros(ncells)
-    dt_u = zeros(nedges)
-    dt_cell = zeros(ncells)
+    dt_iz = zeros(1)
     dt = zeros(1)
+    dt_E = zeros(1)
+    dt_u = zeros(nedges)
 
     cache = (;
-        Aϵ, bϵ, nϵ, B, νan, νc, μ, ϕ, ∇ϕ, ne, Tev, pe, ue, ∇pe,
+        Aϵ, bϵ, nϵ, B, νan, νc, μ, ϕ, ∇ϕ, ne, ϵ, Tev, pe, ue, ∇pe,
         νen, νei, radial_loss_frequency, νew_momentum, νiw, νe, κ, F, UL, UR, Z_eff, λ_global, νiz, νex, K, Id, ji,
         ni, ui, Vs, niui, nn, k, u1, γ_SEE, cell_cache_1,
         error_integral, Id_smoothed, anom_multiplier, smoothing_time_constant,
         errors, dcoeffs,
         ohmic_heating, wall_losses, inelastic_losses,
         channel_area, dA_dz, channel_height, inner_radius, outer_radius, tanδ,
-        anom_variables, dt_iz, dt_E, dt_u, dt, dt_cell
+        anom_variables, dt_iz, dt_E, dt_u, dt
     )
 
     return U, cache
@@ -114,7 +147,7 @@ function setup_simulation(
         Kp = 0.0, Ti = Inf, Td = 0.0, time_constant = 5e-4,
         dtmin = 0.0, dtmax = 1e-7,
     )
-    
+
     #check that Landmark uses the correct thermal conductivity
     if config.LANDMARK && !(config.conductivity_model isa LANDMARK_conductivity)
         error("LANDMARK configuration needs to use the LANDMARK thermal conductivity model.")
@@ -180,7 +213,7 @@ function setup_simulation(
 
     cache.smoothing_time_constant[] = time_constant
     cache.dt .= dt
-    cache.dt_cell .= dt
+
 
     # Simulation parameters
     params = (;

--- a/src/simulation/sourceterms.jl
+++ b/src/simulation/sourceterms.jl
@@ -80,7 +80,7 @@ function apply_ion_acceleration!(dU, U, params)
 end
 
 function apply_ion_wall_losses!(dU, U, params)
-    (;index, config, z_cell, L_ch, ncells, cache) = params
+    (;index, config, z_cell, L_ch, ncells, cache, ncells) = params
     (;ncharge, propellant, wall_loss_model, thruster) = config
 
     if wall_loss_model isa NoWallLosses

--- a/src/simulation/update_electrons.jl
+++ b/src/simulation/update_electrons.jl
@@ -27,7 +27,7 @@ function update_electrons!(params, t = 0)
     # Update other collisions
     @inbounds for i in 1:ncells
         # Compute electron-neutral and electron-ion collision frequencies
-        νen[i] = freq_electron_neutral(params.electron_neutral_collisions, nn[i], Tev[i])
+        νen[i] = freq_electron_neutral(params, i)
 
         # Compute total classical collision frequency
         # If we're not running the LANDMARK benchmark, include momentum transfer due to inelastic collisions

--- a/src/simulation/update_electrons.jl
+++ b/src/simulation/update_electrons.jl
@@ -121,7 +121,7 @@ function integrate_discharge_current(params)
 
     apply_drag = false & !params.config.LANDMARK & (iteration[] > 5)
 
-    if (apply_drag) 
+    if (apply_drag)
         (;νei, νen, νan, ui) = cache
     end
 
@@ -131,7 +131,7 @@ function integrate_discharge_current(params)
 
         int1_1 = (ji[i]   / e / μ[i]   + ∇pe[i])   / ne[i]
         int1_2 = (ji[i+1] / e / μ[i+1] + ∇pe[i+1]) / ne[i+1]
-        
+
         if (apply_drag)
             ion_drag_1 = ui[1, i  ] * (νei[i  ] + νan[i  ]) * me / e
             ion_drag_2 = ui[1, i+1] * (νei[i+1] + νan[i+1]) * me / e
@@ -161,14 +161,13 @@ function compute_electric_field!(∇ϕ, params)
     (;ji, Id, ne, μ, ∇pe, channel_area, ui, νei, νen, νan) = cache
 
     apply_drag = false & !params.config.LANDMARK & (iteration[] > 5)
-    
-    if (apply_drag) 
+
+    if (apply_drag)
         (;νei, νen, νan, ui) = cache
     end
 
 
     for i in eachindex(∇ϕ)
-
         E = ((Id[] / channel_area[i] - ji[i]) / e / μ[i] - ∇pe[i]) / ne[i]
 
         if (apply_drag)

--- a/src/simulation/update_heavy_species.jl
+++ b/src/simulation/update_heavy_species.jl
@@ -38,14 +38,19 @@ function iterate_heavy_species!(dU, U, params; apply_boundary_conditions = true)
             dU[index.ρi[Z],   i] += source_ion_continuity[Z](U, params, i)
             dU[index.ρiui[Z], i] += source_ion_momentum[Z  ](U, params, i)
         end
+    end
 
-        apply_ion_acceleration!(dU, U, params, i)
-        apply_reactions!(dU, U, params, i)
+    apply_reactions!(dU, U, params)
 
-        if ion_wall_losses
-            apply_ion_wall_losses!(dU, U, params, i)
-        end
+    apply_ion_acceleration!(dU, U, params)
 
+    if ion_wall_losses
+        apply_ion_wall_losses!(dU, U, params)
+    end
+
+    @inbounds for i in 2:ncells-1
+        left = left_edge(i)
+        right = right_edge(i)
         params.cache.dt_cell[i] = min(
             sqrt(params.CFL) * params.cache.dt_E[i],
             params.CFL * params.cache.dt_iz[i],

--- a/src/visualization/recipes.jl
+++ b/src/visualization/recipes.jl
@@ -1,5 +1,6 @@
 @recipe function f(sol::Solution, frame::Int = length(sol.u))
     (;z_cell, ionization_reactions, ncharge, L_ch) = sol.params
+    model = params.config.ionization_model
 
     subplot_width = 500
     subplot_height = 500
@@ -105,7 +106,7 @@
                     else
                         reactant_density = sol[:ni, rxn.reactant.Z][frame]
                     end
-                    ionization_rate .+= reactant_density .* ne .* rxn.rate_coeff.(3/2 .* Tev)
+                    ionization_rate .+= reactant_density .* ne .* rate_coeff.(model, rxn, 3/2 .* Tev)
                 end
             end
         end

--- a/src/wall_loss_models/constant_sheath_potential.jl
+++ b/src/wall_loss_models/constant_sheath_potential.jl
@@ -6,14 +6,14 @@ end
 
 freq_electron_wall(::ConstantSheathPotential, params, i) = 1e7
 
-function wall_power_loss(Q, model::ConstantSheathPotential, params)
+function wall_power_loss!(Q, model::ConstantSheathPotential, params)
     (;z_cell, L_ch, config, cache, ncells) = params
     (;ϵ) = cache
     (;sheath_potential, inner_loss_coeff, outer_loss_coeff) = model
 
     @inbounds for i in 2:ncells-1
         αϵ = linear_transition(z_cell[i], L_ch, config.transition_length, inner_loss_coeff, outer_loss_coeff)
-        Q = 1e7 * αϵ * ϵ[i] * exp(-sheath_potential / ϵ[i])
+        Q[i] = 1e7 * αϵ * ϵ[i] * exp(-sheath_potential / ϵ[i])
     end
 
     return nothing

--- a/src/wall_loss_models/constant_sheath_potential.jl
+++ b/src/wall_loss_models/constant_sheath_potential.jl
@@ -6,17 +6,15 @@ end
 
 freq_electron_wall(::ConstantSheathPotential, params, i) = 1e7
 
-function wall_power_loss(model::ConstantSheathPotential, params, i)
-    (;z_cell, L_ch, config, cache) = params
-
-    ne = cache.ne[i]
-    nϵ = cache.nϵ[i]
-    ϵ = nϵ / ne
-
+function wall_power_loss(Q, model::ConstantSheathPotential, params)
+    (;z_cell, L_ch, config, cache, ncells) = params
+    (;ϵ) = cache
     (;sheath_potential, inner_loss_coeff, outer_loss_coeff) = model
-    αϵ = linear_transition(z_cell[i], L_ch, config.transition_length, inner_loss_coeff, outer_loss_coeff)
 
-    W = 1e7 * αϵ * ϵ * exp(-sheath_potential / ϵ)
+    @inbounds for i in 2:ncells-1
+        αϵ = linear_transition(z_cell[i], L_ch, config.transition_length, inner_loss_coeff, outer_loss_coeff)
+        Q = 1e7 * αϵ * ϵ[i] * exp(-sheath_potential / ϵ[i])
+    end
 
-    return W
+    return nothing
 end

--- a/src/wall_loss_models/no_wall_losses.jl
+++ b/src/wall_loss_models/no_wall_losses.jl
@@ -2,4 +2,6 @@ struct NoWallLosses <: WallLossModel end
 
 freq_electron_wall(model::NoWallLosses, params, i) = 0.0
 wall_electron_current(model::NoWallLosses, params, i) = 0.0
-wall_power_loss(model::NoWallLosses, params, i) = 0.0
+function wall_power_loss(Q, model::NoWallLosses, params)
+  Q .= 0.0
+end

--- a/src/wall_loss_models/no_wall_losses.jl
+++ b/src/wall_loss_models/no_wall_losses.jl
@@ -2,6 +2,6 @@ struct NoWallLosses <: WallLossModel end
 
 freq_electron_wall(model::NoWallLosses, params, i) = 0.0
 wall_electron_current(model::NoWallLosses, params, i) = 0.0
-function wall_power_loss(Q, model::NoWallLosses, params)
+function wall_power_loss!(Q, ::NoWallLosses, _)
   Q .= 0.0
 end

--- a/src/wall_loss_models/wall_losses.jl
+++ b/src/wall_loss_models/wall_losses.jl
@@ -13,7 +13,7 @@ Abstract type for wall loss models in the electron energy equation. Types includ
 
 Users implementing their own `WallLossModel` will need to implement at least three methods
     1) `freq_electron_wall(model, params, i)`: Compute the electron-wall momentum transfer collision frequency in cell `i`
-    2) `wall_power_loss(model, params, i)`: Compute the electron power lost to the walls
+    2) `wall_power_loss!(Q, model, params)`: Compute the electron power lost to the walls in array Q
 
 A third method, `wall_electron_current(model, params, i)`, will compute the electron current to the walls in cell `i`. If left unimplemented,
 it defaults to Ie,w = e ne νew V_cell where V_cell is the cell volume.
@@ -27,7 +27,7 @@ function freq_electron_wall(model::WallLossModel, params, i)
     error("freq_electron_wall not implemented for wall loss model of type $(typeof(model)). See documentation for WallLossModel for a list of required methods")
 end
 
-function wall_power_loss(model::WallLossModel, params, i)
+function wall_power_loss(Q, model::WallLossModel, params)
     error("wall_power_loss not implemented for wall loss model of type $(typeof(model)). See documentation for WallLossModel for a list of required methods")
 end
 

--- a/src/wall_loss_models/wall_sheath.jl
+++ b/src/wall_loss_models/wall_sheath.jl
@@ -81,7 +81,7 @@ function freq_electron_wall(model::WallSheath, params, i)
     return νew
 end
 
-function wall_power_loss!(Q, model::WallSheath, params)
+function wall_power_loss!(Q, ::WallSheath, params)
     (;config, cache, z_cell, L_ch, ncells) = params
     mi = config.propellant.m
 

--- a/test/order_verification/ovs_energy.jl
+++ b/test/order_verification/ovs_energy.jl
@@ -2,7 +2,10 @@ module OVS_Energy
 
 include("ovs_funcs.jl")
 
+
 using Symbolics, HallThruster, LinearAlgebra
+
+struct R <: HallThruster.Reaction end
 
 @variables x t
 
@@ -34,7 +37,7 @@ ue_func = eval(build_function(expand_derivatives(ue), [x]))
 nn_func = eval(build_function(nn, [x]))
 ϵ_func = eval(build_function(ϵ, [x]))
 
-k(ϵ) = 8.32 * OVS_rate_coeff_ex(ϵ)
+k(ϵ) = 8.32 * HallThruster.rate_coeff(OVS_Excitation(), R(), ϵ)
 W(ϵ) = 1e7 * ϵ * exp(-20 / ϵ)
 energy_eq = Dt(nϵ) + Dx(5/3 * nϵ * ue - 10/9 * μ * nϵ * Dx(nϵ/ne)) + ne * (-ue * Dx(ϕ) + nn * k(ϵ) + W(ϵ))
 source_energy = eval(build_function(expand_derivatives(energy_eq), [x]))
@@ -65,59 +68,40 @@ end
 
 function verify_energy(ncells; niters = 20000)
     grid = HallThruster.generate_grid(HallThruster.SPT_100.geometry, (0.0, 0.05), UnevenGrid(ncells))
-
     z_cell = grid.cell_centers
     z_edge = grid.edges
     ncells = length(z_cell)
 
-    μ = μ_func.(z_cell)
-    κ = κ_func.(z_cell)
-    ne = ne_func.(z_cell)
-    ϕ = zeros(ncells)
-    ue = ue_func.(z_cell)
-    ∇ϕ = ∇ϕ_func.(z_cell)
-    nn = nn_func.(z_cell)
-    niui = niui_func.(z_cell)
-    Tev = ϵ_func.(z_cell) * 2/3
-    νex = zeros(ncells)
-    νiz = zeros(ncells)
-    channel_area = ones(ncells)
-    dA_dz = zeros(ncells)
+    # fill cache values
+    _, cache = HallThruster.allocate_arrays(grid, (;ncharge=1, anom_model=HallThruster.NoAnom()))
+    @. cache.μ = μ_func(z_cell)
+    @. cache.κ = κ_func(z_cell)
+    @. cache.ne = ne_func(z_cell)
+    @. cache.ue = ue_func(z_cell)
+    @. cache.∇ϕ = ∇ϕ_func(z_cell)
+    @. cache.nn = nn_func(z_cell)
+    @. cache.niui = niui_func(z_cell)'
+    @. cache.Tev = 2/3 * ϵ_func(z_cell)
+    @. cache.channel_area = 1.0
+    @. cache.ni = cache.ne'
 
     nϵ_exact = nϵ_func.(z_cell)
-    pe = copy(nϵ_exact)
+    @. cache.pe = copy(nϵ_exact)
 
-    Te_L = nϵ_exact[1] / ne[1]
-    Te_R = nϵ_exact[end] / ne[end]
-
-    nϵ = Te_L * ne # Set initial temp to 3 eV
-
-    Aϵ = Tridiagonal(ones(ncells-1), ones(ncells), ones(ncells-1))
-    bϵ = zeros(ncells)
-
-    min_electron_temperature = 0.1 * min(Te_L, Te_R)
-
-    source_func = (params, i) -> source_energy(params.z_cell[i])
-
-    # Test backward difference implicit solve
-    dt = 1e-6
-
-    transition_length = 0.0
-
-    excitation_model = OVS_Excitation()
-    ionization_model = OVS_Ionization()
-
-    wall_loss_model = HallThruster.ConstantSheathPotential(20.0, 1.0, 1.0)
-    L_ch = 0.025
-    propellant = HallThruster.Xenon
-    LANDMARK = true
-
-    geometry = (;channel_length = L_ch)
+    Te_L = nϵ_exact[1] / cache.ne[1]
+    Te_R = nϵ_exact[end] / cache.ne[end]
+    @. cache.nϵ = Te_L * cache.ne
 
     config = (;
-        ncharge = 1, source_energy = source_func, implicit_energy = 1.0,
-        min_electron_temperature, transition_length, LANDMARK, propellant,
-        ionization_model, excitation_model, wall_loss_model, geometry,
+        ncharge = 1,
+        source_energy = (params, i) -> source_energy(params.z_cell[i]),
+        min_electron_temperature = 0.1 * min(Te_L, Te_R),
+        transition_length = 0.0,
+        LANDMARK = true,
+        propellant = Xenon,
+        ionization_model = OVS_Ionization(), excitation_model =  OVS_Excitation(),
+        wall_loss_model = HallThruster.ConstantSheathPotential(20.0, 1.0, 1.0),
+        geometry = (;channel_length = 0.025),
         anode_boundary_condition = :dirichlet,
         conductivity_model = HallThruster.LANDMARK_conductivity(),
     )
@@ -132,20 +116,16 @@ function verify_energy(ncells; niters = 20000)
     excitation_reactions = HallThruster._load_reactions(config.excitation_model, species)
     excitation_reactant_indices = HallThruster.reactant_indices(excitation_reactions, species_range_dict)
 
-    wall_losses = zeros(ncells)
-    inelastic_losses = zeros(ncells)
-    ohmic_heating = zeros(ncells)
-    cache = (;
-        Aϵ, bϵ, μ, ϕ, ne, ue, ∇ϕ, Tev, pe, νex, νiz,
-        wall_losses, ohmic_heating, inelastic_losses,
-        channel_area, dA_dz, κ, nϵ, nn, ni = ne, niui
-    )
-
     Δz_cell, Δz_edge = HallThruster.grid_spacing(grid)
 
-    params = (;
-        z_cell, z_edge, Te_L = 2/3 * Te_L, Te_R = 2/3 * Te_R, cache, config,
-        dt, L_ch, propellant,
+    dt = 8 / maximum(abs.(cache.ue)) * (z_cell[2] - z_cell[1])
+    params_base = (;
+        dt,
+        z_cell, z_edge,
+        Te_L = 2/3 * Te_L, Te_R = 2/3 * Te_R,
+        cache = deepcopy(cache),
+        L_ch = config.geometry.channel_length,
+        propellant = config.propellant,
         ionization_reactions,
         ionization_reactant_indices,
         ionization_product_indices,
@@ -155,36 +135,17 @@ function verify_energy(ncells; niters = 20000)
         ncells
     )
 
-    solve_energy!(params, niters, dt)
-    results_implicit = (;z = z_cell, exact = nϵ_exact, sim = params.cache.nϵ[:])
+    # Test backward euler implicit solve
+    params_implicit = (;params_base..., config = (;config..., implicit_energy = 1.0))
+    solve_energy!(params_implicit, niters, dt)
+    results_implicit = (;z = z_cell, exact = nϵ_exact, sim = params_implicit.cache.nϵ[:])
 
     # Test crank-nicholson implicit solve
-    params.cache.nϵ .= ne * Te_L
+    params_cn = (;params_base..., config = (;config..., implicit_energy = 0.5))
+    solve_energy!(params_cn, niters, dt)
+    results_cn = (;z = z_cell, exact = nϵ_exact, sim = params_cn.cache.nϵ[:])
 
-    config = (;
-        ncharge = 1, source_energy = source_func, implicit_energy = 0.5,
-        min_electron_temperature, transition_length, LANDMARK, propellant,
-        ionization_model, excitation_model, wall_loss_model, geometry,
-        anode_boundary_condition = :dirichlet,
-        conductivity_model = HallThruster.LANDMARK_conductivity(),
-    )
-
-    dt = 8 / maximum(abs.(ue)) * (z_cell[2] - z_cell[1])
-    params = (;
-        z_cell, z_edge, Te_L = 2/3 * Te_L, Te_R = 2/3 * Te_R, cache, config,
-        dt, L_ch, propellant,
-        ionization_reactions,
-        ionization_reactant_indices,
-        ionization_product_indices,
-        excitation_reactions,
-        excitation_reactant_indices,
-        Δz_cell, Δz_edge, ncells
-    )
-
-    solve_energy!(params, niters, dt)
-    results_crank_nicholson = (;z = z_cell, exact = nϵ_exact, sim = params.cache.nϵ[:])
-
-    return (results_implicit, results_crank_nicholson)
+    return (results_implicit, results_cn)
 end
 
 end

--- a/test/order_verification/ovs_energy.jl
+++ b/test/order_verification/ovs_energy.jl
@@ -125,14 +125,13 @@ function verify_energy(ncells; niters = 20000)
         Te_L = 2/3 * Te_L, Te_R = 2/3 * Te_R,
         cache = deepcopy(cache),
         L_ch = config.geometry.channel_length,
-        propellant = config.propellant,
         ionization_reactions,
         ionization_reactant_indices,
         ionization_product_indices,
         excitation_reactions,
         excitation_reactant_indices,
         Δz_cell, Δz_edge,
-        ncells
+        ncells,
     )
 
     # Test backward euler implicit solve

--- a/test/order_verification/ovs_funcs.jl
+++ b/test/order_verification/ovs_funcs.jl
@@ -62,23 +62,18 @@ function refines(num_refinements, initial, factor)
     ]
 end
 
-struct OVS_Ionization <: HallThruster.IonizationModel end
-struct OVS_Excitation <: HallThruster.ExcitationModel end
+import HallThruster: load_reactions, rate_coeff, IonizationModel, ExcitationModel, IonizationReaction, ExcitationReaction, Reaction
 
-import HallThruster.load_reactions
+struct OVS_Ionization <: IonizationModel end
+struct OVS_Excitation <: ExcitationModel end
 
-function OVS_rate_coeff_iz(ϵ)
-    return 1e-12 * exp(-12.12/ϵ)
-end
-
-function OVS_rate_coeff_ex(ϵ)
-    return 1e-12 * exp(-8.32/ϵ)
-end
+HallThruster.rate_coeff(::OVS_Ionization, ::Reaction, ϵ) = 1e-12 * exp(-12.12/ϵ)
+HallThruster.rate_coeff(::OVS_Excitation, ::Reaction, ϵ) = 1e-12 * exp(-8.32/ϵ)
 
 function HallThruster.load_reactions(::OVS_Ionization, species)
-    return [HallThruster.IonizationReaction(12.12, HallThruster.Xenon(0), HallThruster.Xenon(1), OVS_rate_coeff_iz.(0:255))]
+    return [IonizationReaction(12.12, Xenon(0), Xenon(1), Float64[])]
 end
 
 function HallThruster.load_reactions(::OVS_Excitation, species)
-    return [HallThruster.ExcitationReaction(8.32, HallThruster.Xenon(0), OVS_rate_coeff_ex.(0:255))]
+    return [ExcitationReaction(8.32, Xenon(0), Float64[])]
 end

--- a/test/order_verification/ovs_funcs.jl
+++ b/test/order_verification/ovs_funcs.jl
@@ -76,9 +76,9 @@ function OVS_rate_coeff_ex(ϵ)
 end
 
 function HallThruster.load_reactions(::OVS_Ionization, species)
-    return [HallThruster.IonizationReaction(12.12, HallThruster.Xenon(0), HallThruster.Xenon(1), OVS_rate_coeff_iz)]
+    return [HallThruster.IonizationReaction(12.12, HallThruster.Xenon(0), HallThruster.Xenon(1), OVS_rate_coeff_iz.(0:255))]
 end
 
 function HallThruster.load_reactions(::OVS_Excitation, species)
-    return [HallThruster.ExcitationReaction(8.32, HallThruster.Xenon(0), OVS_rate_coeff_ex)]
+    return [HallThruster.ExcitationReaction(8.32, HallThruster.Xenon(0), OVS_rate_coeff_ex.(0:255))]
 end

--- a/test/order_verification/ovs_ions.jl
+++ b/test/order_verification/ovs_ions.jl
@@ -115,10 +115,9 @@ function solve_ions(ncells, scheme; t_end = 1e-4)
     dA_dz = zeros(ncells+2)
 
     dt = zeros(1)
-    dt_cell = zeros(ncells+2)
     dt_u = zeros(nedges)
-    dt_iz = zeros(ncells+2)
-    dt_E = zeros(ncells+2)
+    dt_iz = zeros(1)
+    dt_E = zeros(1)
 
     U = zeros(nvars, ncells+2)
     z_end = z_cell[end]
@@ -130,12 +129,11 @@ function solve_ions(ncells, scheme; t_end = 1e-4)
 
     amax = maximum(abs.(ui_exact) .+ sqrt.(2/3 * e * ϵ_func.(z_cell) / mi))
     dt .= 0.1 * minimum(Δz_cell) / amax
-    dt_cell .= dt[]
     k = zeros(size(U))
     u1 = zeros(size(U))
     inelastic_losses = zeros(ncells+2)
     νiz = zeros(ncells+2)
-    cache = (;k, u1, F, UL, UR, ∇ϕ, λ_global, channel_area, dA_dz, dt_cell, dt, dt_u, dt_iz, dt_E, nϵ, νiz, inelastic_losses)
+    cache = (;k, u1, F, UL, UR, ∇ϕ, λ_global, channel_area, dA_dz, dt, dt_u, dt_iz, dt_E, nϵ, νiz, inelastic_losses)
 
     params = (;
         ncells = ncells+2,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,6 @@ using Symbolics
 include("order_verification/ovs_funcs.jl")
 include("order_verification/ovs_energy.jl")
 @testset "Order verification (electron energy)" begin
-
     vfunc = x -> OVS_Energy.verify_energy(x)
     refinements = refines(6, 20, 2)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,8 @@ include("unit_tests/test_json.jl")
 
 using Symbolics
 include("order_verification/ovs_funcs.jl")
-include("order_verification/ovs_energy.jl")
 @testset "Order verification (electron energy)" begin
+    include("order_verification/ovs_energy.jl")
     vfunc = x -> OVS_Energy.verify_energy(x)
     refinements = refines(6, 20, 2)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,8 +48,8 @@ include("order_verification/ovs_funcs.jl")
     end
 end
 
-include("order_verification/ovs_ions.jl")
 @testset "Order verification (neutrals and ions)" begin
+    include("order_verification/ovs_ions.jl")
     refinements = refines(5, 10, 2)
 
     limiter = HallThruster.van_leer

--- a/test/unit_tests/test_electrons.jl
+++ b/test/unit_tests/test_electrons.jl
@@ -62,7 +62,7 @@
 
     U = [mi * nn; mi * ne; ne * 3/2 * Tev ;;]
     @test HallThruster.freq_electron_neutral(params_landmark, 1) == 2.5e-13 * nn
-    @test HallThruster.freq_electron_neutral(params_gk, 1) == HallThruster.σ_en(Tev) * nn * sqrt(8 * e * Tev / π / me)
+    @test isapprox(HallThruster.freq_electron_neutral(params_gk, 1), HallThruster.σ_en(Tev) * nn * sqrt(8 * e * Tev / π / me), rtol = 0.01)
     @test HallThruster.freq_electron_neutral(params_none, 1) == 0.0
 
     Z = 1

--- a/test/unit_tests/test_initialization.jl
+++ b/test/unit_tests/test_initialization.jl
@@ -113,10 +113,10 @@ end
     @test fluid_ranges == [1:1, 2:3, 4:5, 6:7]
     @test species == [Xenon(0), Xenon(1), Xenon(2), Xenon(3)]
     @test species_range_dict == Dict(
-        Symbol("Xe") => [1:1],
-        Symbol("Xe+") => [2:3],
-        Symbol("Xe2+") => [4:5],
-        Symbol("Xe3+") => [6:7],
+        Symbol("Xe") => 1:1,
+        Symbol("Xe+") => 2:3,
+        Symbol("Xe2+") => 4:5,
+        Symbol("Xe3+") => 6:7,
     )
 
     @test fluids[1] == HallThruster.ContinuityOnly(species[1], config.neutral_velocity, config.neutral_temperature)
@@ -133,14 +133,14 @@ end
     # load collisions and reactions
     ionization_reactions = HallThruster._load_reactions(config.ionization_model, unique(species))
     ionization_reactant_indices = HallThruster.reactant_indices(ionization_reactions, species_range_dict)
-    @test ionization_reactant_indices == [[1], [1], [1], [2], [2], [4]]
+    @test ionization_reactant_indices == [1, 1, 1, 2, 2, 4]
 
     ionization_product_indices = HallThruster.product_indices(ionization_reactions, species_range_dict)
-    @test ionization_product_indices == [[2], [4], [6], [4], [6], [6]]
+    @test ionization_product_indices == [2, 4, 6, 4, 6, 6]
 
     excitation_reactions = HallThruster._load_reactions(config.excitation_model, unique(species))
     excitation_reactant_indices = HallThruster.reactant_indices(excitation_reactions, species_range_dict)
-    @test excitation_reactant_indices == [[1]]
+    @test excitation_reactant_indices == [1]
 
     # Test that initialization and configuration works properly when background neutrals are included
 
@@ -157,10 +157,10 @@ end
     @test fluid_ranges == [1:1, 2:3, 4:5, 6:7]
     @test species == [Xenon(0), Xenon(1), Xenon(2), Xenon(3)]
     @test species_range_dict == Dict(
-        Symbol("Xe") => [1:1],
-        Symbol("Xe+") => [2:3],
-        Symbol("Xe2+") => [4:5],
-        Symbol("Xe3+") => [6:7],
+        Symbol("Xe") => 1:1,
+        Symbol("Xe+") => 2:3,
+        Symbol("Xe2+") => 4:5,
+        Symbol("Xe3+") => 6:7,
     )
 
     @test fluids[1] == HallThruster.ContinuityOnly(species[1], config.neutral_velocity, config.neutral_temperature)
@@ -177,12 +177,12 @@ end
     # load collisions and reactions
     ionization_reactions = HallThruster._load_reactions(config.ionization_model, unique(species))
     ionization_reactant_indices = HallThruster.reactant_indices(ionization_reactions, species_range_dict)
-    @test ionization_reactant_indices == [[1], [1], [1], [2], [2], [4]]
+    @test ionization_reactant_indices == [1, 1, 1, 2, 2, 4]
 
     ionization_product_indices = HallThruster.product_indices(ionization_reactions, species_range_dict)
-    @test ionization_product_indices == [[2], [4], [6], [4], [6], [6]]
+    @test ionization_product_indices == [2, 4, 6, 4, 6, 6]
 
     excitation_reactions = HallThruster._load_reactions(config.excitation_model, unique(species))
     excitation_reactant_indices = HallThruster.reactant_indices(excitation_reactions, species_range_dict)
-    @test excitation_reactant_indices == [[1]]
+    @test excitation_reactant_indices == [1]
 end

--- a/test/unit_tests/test_initialization.jl
+++ b/test/unit_tests/test_initialization.jl
@@ -27,7 +27,7 @@
     ncells = 100
     fluids, fluid_ranges, species, species_range_dict, is_velocity_index = HallThruster.configure_fluids(config)
     grid = HallThruster.generate_grid(config.thruster.geometry, domain, EvenGrid(ncells))
-    U, cache = HallThruster.allocate_arrays(grid, fluids, config.anom_model)
+    U, cache = HallThruster.allocate_arrays(grid, config)
     index = HallThruster.configure_index(fluids, fluid_ranges)
 
     params = (;

--- a/test/unit_tests/test_misc.jl
+++ b/test/unit_tests/test_misc.jl
@@ -92,21 +92,20 @@ end
     @test length(grid.edges) == ncells+1
 
     Xe_0 = HallThruster.Fluid(HallThruster.Xenon(0), 100., 100.)
-    Xe_0_background = HallThruster.Fluid(HallThruster.Xenon(0), 100., 100.)
     Xe_I = HallThruster.Fluid(HallThruster.Xenon(1), T = 100.)
     Xe_II = HallThruster.Fluid(HallThruster.Xenon(2), T = 100.)
-    Xe_III = HallThruster.Fluid(HallThruster.Xenon(3))
+    Xe_III = HallThruster.Fluid(HallThruster.Xenon(3), T = 300.0)
     fluids = [
-        Xe_0,
         Xe_0,
         Xe_I,
         Xe_II,
         Xe_III
     ]
 
-    nvars = 2 + 2 + 2 + 3
+    nvars = 1 + 2 + 2 + 2
+    config = (;ncharge = 3, anom_model = HallThruster.NoAnom())
 
-    U, cache = HallThruster.allocate_arrays(grid, fluids)
+    U, cache = HallThruster.allocate_arrays(grid, config)
 
     @test size(U) == (nvars, ncells+2)
 

--- a/test/unit_tests/test_reactions.jl
+++ b/test/unit_tests/test_reactions.jl
@@ -49,7 +49,7 @@
     @test_throws ArgumentError HallThruster._load_reactions(landmark_lut, [Xe_0, Xe_I, Xe_II, Xe_III])
     landmark_rxns = HallThruster._load_reactions(landmark_lut, [Xe_0, Xe_I])
     @test length(landmark_rxns) == 1
-    @test HallThruster.rate_coeff(landmark_rxns[1], 19.0) ≈ 5.690E-14
+    @test HallThruster.rate_coeff(landmark_lut, landmark_rxns[1], 19.0) ≈ 5.690E-14
 
     # Test behavior of general lookup
     @test_throws ArgumentError HallThruster.load_reactions(lookup, [Ar_0, Ar_I])
@@ -69,12 +69,12 @@
     lookup_2 = HallThruster.IonizationLookup([joinpath(HallThruster.PACKAGE_ROOT, "test", "unit_tests", "reaction_tests")])
     lookup_2_rxns = HallThruster._load_reactions(lookup_2, [Ar_0, Ar_I])
     @test length(lookup_2_rxns) == 1
-    @test HallThruster.rate_coeff(lookup_2_rxns[1], 0.3878e-01) |> abs < eps(Float64)
+    @test HallThruster.rate_coeff(lookup_2, lookup_2_rxns[1], 0.3878e-01) |> abs < eps(Float64)
     @test lookup_2_rxns[1].energy == 13.0
     lookup_2_rxns_Xe = HallThruster._load_reactions(lookup_2, [Xe_0, Xe_I, Xe_II, Xe_III])
     @test length(lookup_2_rxns_Xe) == 6
-    @test HallThruster.rate_coeff(lookup_2_rxns_Xe[1], 1.0) |> abs < eps(Float64)
-    @test HallThruster.rate_coeff(lookup_2_rxns_Xe[1], 1.0) != HallThruster.rate_coeff(lookup_rxns[1], 1.0)
+    @test HallThruster.rate_coeff(lookup_2, lookup_2_rxns_Xe[1], 1.0) |> abs < eps(Float64)
+    @test HallThruster.rate_coeff(lookup_2, lookup_2_rxns_Xe[1], 1.0) != HallThruster.rate_coeff(lookup, lookup_rxns[1], 1.0)
     @test lookup_2_rxns_Xe[1].energy == 15.0
 
     # Excitation reactions
@@ -86,13 +86,13 @@
     ex_rxns = HallThruster._load_reactions(ex_lookup, [Xe_0])
     @test length(ex_rxns) == 1
     @test ex_rxns[1].energy == 8.32
-    @test HallThruster.rate_coeff(ex_rxns[1], 10.0) ≈ 2.358251483e-14
+    @test HallThruster.rate_coeff(ex_lookup, ex_rxns[1], 10.0) ≈ 2.358251483e-14
 
     ex_lookup_2 = HallThruster.ExcitationLookup([joinpath(HallThruster.PACKAGE_ROOT, "test", "unit_tests", "reaction_tests")])
     @test !isempty(HallThruster._load_reactions(ex_lookup_2, [Ar_0]))
     ex_rxns = HallThruster._load_reactions(ex_lookup_2, [Ar_0])
     @test ex_rxns[1].energy == 10.0
-    @test HallThruster.rate_coeff(ex_rxns[1], 1.0) |> abs < eps(Float64)
+    @test HallThruster.rate_coeff(ex_lookup_2, ex_rxns[1], 1.0) |> abs < eps(Float64)
 
     ex_lookup_landmark = HallThruster.LandmarkExcitationLookup()
     ex_landmark_rxn = HallThruster.load_reactions(ex_lookup_landmark, [Xe_0])[1]
@@ -102,5 +102,5 @@
     loss_itp = HallThruster.LinearInterpolation(landmark_table[:, 1], landmark_table[:, 3])
     iz_landmark_rxn = landmark_rxns[1]
 
-    @test 8.32 * HallThruster.rate_coeff(ex_landmark_rxn, 14.32) + 12.12 * HallThruster.rate_coeff(iz_landmark_rxn, 14.32) ≈ loss_itp(14.32)
+    @test 8.32 * HallThruster.rate_coeff(ex_lookup_landmark, ex_landmark_rxn, 14.32) + 12.12 * HallThruster.rate_coeff(landmark_lut, iz_landmark_rxn, 14.32) ≈ loss_itp(14.32)
 end

--- a/test/unit_tests/test_restarts.jl
+++ b/test/unit_tests/test_restarts.jl
@@ -31,8 +31,8 @@
     @test sol.t == restart.t
 
     # test loading restart, generating cache, U, etc, without interpolation, changing number of charges, or changing domain
-    U, cache = HallThruster.load_restart(grid, fluids, config, sol)
-    U2, cache2 = HallThruster.load_restart(grid, fluids, config, restart_path)
+    U, cache = HallThruster.load_restart(grid, config, sol)
+    U2, cache2 = HallThruster.load_restart(grid, config, restart_path)
 
     # Check that we get the same result by loading solution directly or by loading filename
     @test U == U2

--- a/test/unit_tests/test_walls.jl
+++ b/test/unit_tests/test_walls.jl
@@ -66,9 +66,13 @@
         Δz_edge, Δz_cell, γ_SEE_max = γmax
     )
 
-    @test HallThruster.wall_power_loss(no_losses, params, 2) == 0.0
-    @test HallThruster.wall_power_loss(landmark_losses, params, 2) ≈ αin *  6.0 * 1e7 * exp(-20 / 6.0)
-    @test HallThruster.wall_power_loss(landmark_losses, params, 3) ≈ αout *  6.0 * 1e7 * exp(-20 / 6.0)
+    arr = zeros(6)
+    HallThruster.wall_power_loss!(arr, no_losses, params)
+    @test arr[2] == 0.0
+
+    HallThruster.wall_power_loss!(arr, landmark_losses, params)
+    @test arr[2] ≈ αin *  6.0 * 1e7 * exp(-20 / 6.0)
+    @test arr[3] ≈ αout *  6.0 * 1e7 * exp(-20 / 6.0)
 
     γ1 = 0.5
     γ2 = 1.0
@@ -121,8 +125,9 @@
     @test HallThruster.freq_electron_wall(sheath_model, params, 2) * HallThruster.linear_transition(params.z_cell[2], L_ch, params.config.transition_length, 1.0, 0.0) ≈ νew
     @test HallThruster.freq_electron_wall(sheath_model, params, 3) * HallThruster.linear_transition(params.z_cell[3], L_ch, params.config.transition_length, 1.0, 0.0) ≈ 0.0
 
-    @test HallThruster.wall_power_loss(sheath_model, params, 2) ≈ νew * (2 * Tev + (1 - γ) * Vs)
-    @test HallThruster.wall_power_loss(sheath_model, params, 4) ≈ 0.0
+    HallThruster.wall_power_loss!(arr, sheath_model, params)
+    @test arr[2] ≈ νew * (2 * Tev + (1 - γ) * Vs)
+    @test arr[4] ≈ 0.0
 end
 
 @testset "Ion wall losses" begin

--- a/test/unit_tests/test_walls.jl
+++ b/test/unit_tests/test_walls.jl
@@ -19,6 +19,7 @@
         ne = [ne, ne, ne, ne],
         ni = [ne ne ne ne],
         Tev = [Tev, Tev, Tev, Tev],
+        ϵ = 1.5 .* [Tev, Tev, Tev, Tev],
         nϵ = [nϵ, nϵ, nϵ, nϵ],
         Z_eff = [1.0, 1.0, 1.0, 1.0],
         γ_SEE = [0.0, 0.0, 0.0, 0.0],
@@ -34,6 +35,7 @@
     )
     index = (;ρi = [1], nϵ = 2)
 
+    ncells = 2
     grid = HallThruster.generate_grid(HallThruster.geometry_SPT_100, (0, 2 * L_ch), EvenGrid(2))
 
     z_cell = grid.cell_centers
@@ -63,10 +65,10 @@
     params = (;
         cache, config, index, z_cell = grid.cell_centers,
         z_edge = grid.edges, L_ch = L_ch, A_ch = A_ch,
-        Δz_edge, Δz_cell, γ_SEE_max = γmax
+        Δz_edge, Δz_cell, γ_SEE_max = γmax, ncells = ncells+2
     )
 
-    arr = zeros(6)
+    arr = zeros(ncells+2)
     HallThruster.wall_power_loss!(arr, no_losses, params)
     @test arr[2] == 0.0
 
@@ -219,7 +221,7 @@ end
     z_edge = grid.edges
     z_cell = grid.cell_centers
     γ_SEE_max = 1 - 8.3 * sqrt(HallThruster.me/mi)
-    base_params = (;cache, L_ch, A_ch, fluids, z_cell, z_edge, index, Δz_cell, Δz_edge, γ_SEE_max)
+    base_params = (;cache, L_ch, A_ch, fluids, z_cell, z_edge, index, Δz_cell, Δz_edge, γ_SEE_max, ncells=4)
 
     config_no_losses = (;config..., wall_loss_model = HallThruster.NoWallLosses())
     params_no_losses = (;base_params..., config = config_no_losses)
@@ -232,8 +234,7 @@ end
     u_bohm_2 = sqrt(2) * u_bohm
 
     # Test 1: no wall losses
-    HallThruster.apply_ion_wall_losses!(dU, U, params_no_losses, 2)
-    HallThruster.apply_ion_wall_losses!(dU, U, params_no_losses, 3)
+    HallThruster.apply_ion_wall_losses!(dU, U, params_no_losses)
 
     @test all(dU .≈ 0.0)
 
@@ -254,7 +255,7 @@ end
 
     dU .= 0.0
     # Check that wall losses work correctly
-    HallThruster.apply_ion_wall_losses!(dU, U, params_constant_sheath, i)
+    HallThruster.apply_ion_wall_losses!(dU, U, params_constant_sheath)
 
     # Neutrals should recombine at walls
     @test dU[index.ρn, i] ≈ -(dU[index.ρi[1], i] + dU[index.ρi[2], i])
@@ -279,7 +280,7 @@ end
     @test HallThruster.wall_ion_current(constant_sheath, params_constant_sheath, i, 2) == 0.0
     @test HallThruster.wall_electron_current(constant_sheath, params_constant_sheath, i) == 0.0
 
-    HallThruster.apply_ion_wall_losses!(dU, U, params_constant_sheath, 3)
+    HallThruster.apply_ion_wall_losses!(dU, U, params_constant_sheath)
     @test all(dU[:, 3] .≈ 0.0)
 
     # Test 3: Self-consistent wall sheath
@@ -304,7 +305,7 @@ end
     @test Iiw_2 ≈ 2 * Iew * ni_2 / ne * (1 - γ)
     @test Iew ≈ inv(1 - γ) * (Iiw_1 + Iiw_2)
 
-    HallThruster.apply_ion_wall_losses!(dU, U, params_wall_sheath, i)
+    HallThruster.apply_ion_wall_losses!(dU, U, params_wall_sheath)
 
     # Neutrals should recombine at walls
     @test dU[index.ρn, i] ≈ -(dU[index.ρi[1], i] + dU[index.ρi[2], i])
@@ -323,6 +324,6 @@ end
     @test HallThruster.wall_ion_current(wall_sheath, params_wall_sheath, i, 2) == 0.0
     @test HallThruster.wall_electron_current(wall_sheath, params_wall_sheath, i) == 0.0
 
-    HallThruster.apply_ion_wall_losses!(dU, U, params_wall_sheath, 3)
+    HallThruster.apply_ion_wall_losses!(dU, U, params_wall_sheath)
     @test all(dU[:, 3] .≈ 0.0)
 end


### PR DESCRIPTION
Reactions have been refactored to make use of a look-up table by default instead of a linear interpolation.
Additionally, I have rearranged a significant part of the reaction infrastructure to enable better vectorization.
Lastly, the OVS tests have been simplified and made more reliable.

Overall, when using 3 charge states, this update looks to provide a 30-40% speedup in overall runtime.