### PR TITLE
Adaptive timestepper now takes longer steps after long sequence of short steps

### DIFF
--- a/src/simulation/json.jl
+++ b/src/simulation/json.jl
@@ -152,12 +152,16 @@ function run_simulation(json_content::JSON3.Object; verbose = true)
     num_cells = get_key(json_content, :num_cells, 200)
     duration_s = get_key(json_content, :duration_s, 1e-3)
     dt_s = get_key(json_content, :dt_s, 1e-8)
+    dtmin = get_key(json_content, :min_dt_s, 1e-10)
+    dtmax = get_key(json_content, :max_dt_s, 1e-7)
+    max_small_steps = get_key(json_content, :max_small_steps, 100)
 
     config = config_from_json(json_content)
 
     solution = run_simulation(
         config; grid = EvenGrid(num_cells), nsave = num_save,
-        duration = duration_s, dt = dt_s, verbose = verbose, adaptive
+        duration = duration_s, dt = dt_s, verbose = verbose, adaptive,
+        dtmin, dtmax, max_small_steps,
     )
 
     return solution

--- a/src/simulation/simulation.jl
+++ b/src/simulation/simulation.jl
@@ -136,7 +136,7 @@ function setup_simulation(
         CFL = 0.799, adaptive = false,
         control_current = false, target_current = 0.0,
         Kp = 0.0, Ti = Inf, Td = 0.0, time_constant = 5e-4,
-        dtmin = 0.0, dtmax = 1e-7,
+        dtmin = 1e-10, dtmax = 1e-7, max_small_steps = 100,
     )
 
     #check that Landmark uses the correct thermal conductivity
@@ -146,6 +146,7 @@ function setup_simulation(
 
     # If dt is provided with units, convert to seconds and then strip units
     dt = convert_to_float64(dt, u"s")
+    dtbase = dt
 
     fluids, fluid_ranges, species, species_range_dict, is_velocity_index = configure_fluids(config)
 
@@ -238,7 +239,7 @@ function setup_simulation(
         Δz_cell, Δz_edge,
         control_current, target_current, Kp, Ti, Td,
         exit_plane_index = findfirst(>=(config.thruster.geometry.channel_length), z_cell) - 1,
-        dtmin, dtmax,
+        dtbase, dtmin, dtmax, max_small_steps,
         # landmark benchmark uses pe = 3/2 ne Te, otherwise use pe = ne Te
         pe_factor = config.LANDMARK ? 3/2 : 1.0
     )

--- a/src/simulation/solution.jl
+++ b/src/simulation/solution.jl
@@ -71,11 +71,8 @@ function solve(U, params, tspan; saveat)
         end
 
         if small_step_count >= params.max_small_steps
-            println("taking uniform steps: time  = ", t)
-            println("expected increment: ", params.max_small_steps * params.dtbase)
             uniform_steps = true
         elseif small_step_count == 0
-            println("done taking uniform steps: time = ", t)
             uniform_steps = false
         end
 
@@ -125,7 +122,6 @@ function solve(U, params, tspan; saveat)
         # Save values at designated intervals
         # TODO interpolate these to be exact and make a bit more elegant
         if t > saveat[save_ind]
-            println(params.dt[])
             u_save[save_ind] .= U
 
             # save vector fields


### PR DESCRIPTION
This PR modifies the adaptive timestepping logic. If the timestep has been stuck at the smallest possible timestep for some number of iterations (configurable as `max_small_steps` in the `run_simulation` function, default = 100), the code will use the nominal value (`dt` in `run_simulation`) for the same number of iterations before switching adaptivity back on. This feature helps the adaptive timestepper overcome some points where it might get stuck.

In addition, the "max_dt_s", "min_dt_s", and "max_small_steps" keys have been added to JSON. These control, respectively, the maximum allowable timestep, the minimum allowable timeste, and the above `max_small_steps` parameters

@MetisArom