### PR TITLE
Charge State indexing fix

### DIFF
--- a/src/simulation/json.jl
+++ b/src/simulation/json.jl
@@ -77,9 +77,9 @@ function frame_dict(sol::Solution, frame::Integer)
     if length(sol.config.propellants) == 1
         symbol = sol.config.propellants[1].gas.short_name
         d["nn"] = f.neutrals[symbol].n
-        d["ni"] = [ion.n for ion in f.ions[symbol]]
-        d["ui"] = [ion.u for ion in f.ions[symbol]]
-        d["niui"] = [ion.nu for ion in f.ions[symbol]]
+        d["ni"] = [ion.n for ion in values(f.ions[symbol])]
+        d["ui"] = [ion.u for ion in values(f.ions[symbol])]
+        d["niui"] = [ion.nu for ion in values(f.ions[symbol])]
     end
 
     d["neutrals"] = OrderedDict(
@@ -98,7 +98,7 @@ function frame_dict(sol::Solution, frame::Integer)
                     "nu" => ion.nu,
                     "Z" => ion.Z,
                 )
-                for ion in ions
+                for ion in values(ions)
             ]
             for (symbol, ions) in pairs(f.ions)
     )

--- a/src/simulation/postprocess.jl
+++ b/src/simulation/postprocess.jl
@@ -39,7 +39,7 @@ function time_average(sol::Solution, start_frame::Integer = 1)
         elseif f == :ions
             for prop in sol.config.propellants
                 symbol = prop.gas.short_name
-                for ion in avg[symbol]
+                for ion in values(avg[symbol])
                     ion.n .= 0.0
                     ion.nu .= 0.0
                     ion.u .= 0.0
@@ -71,10 +71,10 @@ function time_average(sol::Solution, start_frame::Integer = 1)
             elseif f == :ions
                 for prop in sol.config.propellants
                     symbol = prop.gas.short_name
-                    for (j, ion) in enumerate(avg[symbol])
-                        ion.n .+= field[symbol][j].n ./ dt
-                        ion.nu .+= field[symbol][j].nu ./ dt
-                        ion.u .+= field[symbol][j].u ./ dt
+                    for Z in prop.allowed_charges
+                        avg[symbol][Z].n.+= field[symbol][Z].n ./ dt
+                        avg[symbol][Z].nu .+= field[symbol][Z].nu ./ dt
+                        avg[symbol][Z].u .+= field[symbol][Z].u ./ dt
                     end
                 end
             else
@@ -106,7 +106,7 @@ function thrust(sol::Solution, frame::Integer)
     thrust = 0.0
 
     for ions in values(f.ions)
-        for ion in ions
+        for ion in values(ions)
             thrust += right_area * ion.m * ion.nu[end]^2 / ion.n[end]
             thrust -= left_area * ion.m * ion.nu[begin]^2 / ion.n[begin]
         end
@@ -253,7 +253,7 @@ function mass_eff(sol::Solution, frame)
     mdot_i = 0.0
 
     for ions in values(f.ions)
-        for ion in ions
+        for ion in values(ions)
             mdot_i += ion.m * ion.nu[end] * right_area
         end
     end

--- a/src/simulation/solution.jl
+++ b/src/simulation/solution.jl
@@ -54,7 +54,7 @@ end
 
 function _get_species_states(fluids_by_propellant)
     neutrals = OrderedDict{Symbol, SpeciesState}()
-    ions = OrderedDict{Symbol, Vector{SpeciesState}}()
+    ions = OrderedDict{Symbol, OrderedDict{Int, SpeciesState}}()
 
     for fluids in fluids_by_propellant
         continuity = fluids.continuity[1]
@@ -69,14 +69,14 @@ function _get_species_states(fluids_by_propellant)
         remove_ghosts!(neutral_state)
         neutrals[symbol] = neutral_state
 
-        ion_states = SpeciesState[]
+        ion_states = OrderedDict{Int, SpeciesState}()
         for ion in fluids.isothermal
             ion_state = SpeciesState(length(ion.density), m, ion.species.Z)
             @. ion_state.n = ion.density * inv_m
             @. ion_state.nu = ion.momentum * inv_m
             @. ion_state.u = ion.momentum / ion.density
             remove_ghosts!(ion_state)
-            push!(ion_states, ion_state)
+            ion_states[ion.species.Z] = ion_state
         end
         ions[symbol] = ion_states
     end
@@ -99,7 +99,7 @@ $(TYPEDFIELDS)
     """Dictionary containing neutral species. Indexed by that species' symbol."""
     neutrals::OrderedDict{Symbol, SpeciesState}
     """Dictionary containing ion species. Indexed by the species' symbol, followed by charge state."""
-    ions::OrderedDict{Symbol, Vector{SpeciesState}}
+    ions::OrderedDict{Symbol, OrderedDict{Int, SpeciesState}}
     """Magnetic field strength (T)"""
     B::Vector{Float64}
     """Plasma density (1/m^3)"""
@@ -447,11 +447,11 @@ function Base.getindex(sol::Solution, field::Symbol)
     if field == :nn
         return [frame.neutrals[symbol].n for frame in sol.frames]
     elseif field == :ni
-        return [[frame.ions[symbol][Z].n[i] for Z in eachindex(allowed), i in 1:ncells] for frame in sol.frames]
+        return [[frame.ions[symbol][Z].n[i] for Z in allowed, i in 1:ncells] for frame in sol.frames]
     elseif field == :niui
-        return [[frame.ions[symbol][Z].nu[i] for Z in eachindex(allowed), i in 1:ncells] for frame in sol.frames]
+        return [[frame.ions[symbol][Z].nu[i] for Z in allowed, i in 1:ncells] for frame in sol.frames]
     elseif field == :ui
-        return [[frame.ions[symbol][Z].u[i] for Z in eachindex(allowed), i in 1:ncells] for frame in sol.frames]
+        return [[frame.ions[symbol][Z].u[i] for Z in allowed, i in 1:ncells] for frame in sol.frames]
     end
 
     throw(ArgumentError("Field :$(field) not found! Valid fields are $(valid_fields())"))


### PR DESCRIPTION
I changed the way charge state is stored from an array index to an ordered dict in postprocessing. This allows for indexing with negative charge states. addresses #157 