### PR TITLE
Boundary fix 2

### DIFF
--- a/src/simulation/heavy_species_update.jl
+++ b/src/simulation/heavy_species_update.jl
@@ -308,19 +308,18 @@ function apply_left_boundary!(fluids, propellant, cache, anode_bc, ingestion_flo
             neutral_density -= boundary_flux / un
 
         else
-            # Negative ions: repelled by sheath
-            sound_speed = sqrt(kTi_J / mi)
-            boundary_velocity = 0.0
+            KE = 0.5 * mi * interior_velocity^2
+            barrier = abs(Z) * e * Vs
 
-            if interior_velocity >= 0.0
-                # Already flowing away from anode → Neumann
+            if KE >= barrier
+                # Ion reaches anode with reduced speed
+                KE_boundary = KE - barrier
+                boundary_velocity = -sqrt(2 * KE_boundary / mi)  # toward anode
                 boundary_density = interior_density
-                boundary_flux = interior_density * interior_velocity
+                boundary_flux = boundary_density * boundary_velocity
             else
-                # Would leave domain → clamp to zero velocity
-                J⁻ = interior_velocity - sound_speed * log(interior_density)
-                J⁺ = -J⁻
-                boundary_density = exp(0.5 * (J⁺ - J⁻) / sound_speed)
+                # Reflected
+                boundary_density = interior_density
                 boundary_flux = 0.0
             end
         end

--- a/src/simulation/solution.jl
+++ b/src/simulation/solution.jl
@@ -515,12 +515,28 @@ function solve(params, config, tspan; num_save = -1)
 
     try
         while true
-            # Run the heavy species solver and check for NaN or Inf
             any_nan = integrate_heavy_species!(params.fluid_containers, params, source_heavy_species, params.dt[])
 
             if any_nan
                 if sim.print_errors
-                    @warn("NaN or Inf detected in heavy species solver at time $(t)")
+                    # Find which fluids/cells have NaN or Inf
+                    for (i, fluid) in enumerate(params.fluid_array)
+                        nan_density = findall(x -> !isfinite(x), fluid.density)
+                        nan_momentum = findall(x -> !isfinite(x), fluid.momentum)
+                        if !isempty(nan_density)
+                            @warn("NaN/Inf in ($(fluid.species.symbol), Z=$(fluid.species.Z)) density at cells: $nan_density (values: $(fluid.density[nan_density]))")
+                        end
+                        if !isempty(nan_momentum)
+                            @warn("NaN/Inf in ($(fluid.species.symbol), Z=$(fluid.species.Z)) momentum at cells: $nan_momentum (values: $(fluid.momentum[nan_momentum]))")
+                        end
+                    end
+                    # Report timestep and time context
+                    @warn(
+                        "NaN/Inf detected in heavy species solver",
+                        time = t,
+                        dt = params.dt[],
+                        iteration = params.iteration[],
+                    )
                 end
                 retcode = :failure
                 break


### PR DESCRIPTION
After adding the diagnostics in the previous PR, I realized that negative ion density was blowing up near the anode so I changed the previous additions I made there. The negative ions now will have the sheath energy subracted from their kinetic energy or if their kinetic energy is lower than the sheath potential, a 0 flux condition is imposed. addresses #157 runs until 8.65e-5 seconds.